### PR TITLE
Fix shift balancing adjustment

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifter.java
@@ -133,9 +133,7 @@ public final class SweNetworkShifter implements NetworkShifter {
                 } else {
                     // Reset current variant with initial state for each iteration
                     network.getVariantManager().cloneVariant(initialVariantId, workingVariantCopyId, true);
-                    scalingValuesByCountry.put(toEic("PT"), scalingValuesByCountry.get(toEic("PT")) - mismatchEsPt);
-                    scalingValuesByCountry.put(toEic("FR"), scalingValuesByCountry.get(toEic("FR")) - mismatchEsFr);
-                    scalingValuesByCountry.put(toEic("ES"), scalingValuesByCountry.get(toEic("ES")) + mismatchEsPt + mismatchEsFr);
+                    updateScalingValuesWithMismatch(scalingValuesByCountry, mismatchEsPt, mismatchEsFr);
                     ++iterationCounter;
                 }
 
@@ -155,6 +153,22 @@ public final class SweNetworkShifter implements NetworkShifter {
             // here set working variant generators pmin and pmax values to initial values
             resetInitialPminPmax(network, zonalScalable, zoneIds, initGenerators);
         }
+    }
+
+    void updateScalingValuesWithMismatch(Map<String, Double> scalingValuesByCountry, double mismatchEsPt, double mismatchEsFr) {
+        switch (direction) {
+            case ES_FR:
+            case FR_ES:
+                scalingValuesByCountry.put(toEic("FR"), scalingValuesByCountry.get(toEic("FR")) - mismatchEsFr);
+                break;
+
+            case ES_PT:
+            case PT_ES:
+                scalingValuesByCountry.put(toEic("PT"), scalingValuesByCountry.get(toEic("PT")) - mismatchEsPt);
+                break;
+        }
+
+        scalingValuesByCountry.put(toEic("ES"), scalingValuesByCountry.get(toEic("ES")) + mismatchEsPt + mismatchEsFr);
     }
 
     Map<String, Double> getTargetExchanges(double stepValue) {

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
@@ -15,6 +15,7 @@ import com.farao_community.farao.swe.runner.app.dichotomy.DichotomyDirection;
 import com.powsybl.glsk.commons.ZonalDataImpl;
 import com.powsybl.iidm.modification.scalable.Scalable;
 import com.powsybl.iidm.network.Network;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,6 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 class SweNetworkShifterTest {
 
+    private static final String EIC_FR = "10YFR-RTE------C";
+    private static final String EIC_ES = "10YES-REE------0";
+    private static final String EIC_PT = "10YPT-REN------W";
     @MockBean
     private ProcessConfiguration processConfiguration;
 
@@ -211,5 +215,69 @@ class SweNetworkShifterTest {
                 DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
+    }
+
+    @Test
+    void updateScalingValuesWithMismatchPtEsTest() {
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration);
+        Map<String, Double> scalingValuesByCountry = new HashMap<>(
+            Map.of(EIC_FR, 12.0,
+                EIC_ES, 27.0,
+                EIC_PT, 1515.0));
+
+        networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
+
+        Assertions.assertThat(scalingValuesByCountry)
+            .containsEntry(EIC_FR, 12.0)
+            .containsEntry(EIC_ES, 45.0)
+            .containsEntry(EIC_PT, 1510.0);
+    }
+
+    @Test
+    void updateScalingValuesWithMismatchEsPtTest() {
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration);
+        Map<String, Double> scalingValuesByCountry = new HashMap<>(
+            Map.of(EIC_FR, 12.0,
+                EIC_ES, 27.0,
+                EIC_PT, 1515.0));
+
+        networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
+
+        Assertions.assertThat(scalingValuesByCountry)
+            .containsEntry(EIC_FR, 12.0)
+            .containsEntry(EIC_ES, 45.0)
+            .containsEntry(EIC_PT, 1510.0);
+    }
+
+    @Test
+    void updateScalingValuesWithMismatchFrEsTest() {
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration);
+        Map<String, Double> scalingValuesByCountry = new HashMap<>(
+            Map.of(EIC_FR, 12.0,
+                EIC_ES, 27.0,
+                EIC_PT, 1515.0));
+
+        networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
+
+        Assertions.assertThat(scalingValuesByCountry)
+            .containsEntry(EIC_FR, -1.0)
+            .containsEntry(EIC_ES, 45.0)
+            .containsEntry(EIC_PT, 1515.0);
+    }
+
+    @Test
+    void updateScalingValuesWithMismatchEsFrTest() {
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration);
+        Map<String, Double> scalingValuesByCountry = new HashMap<>(
+            Map.of(EIC_FR, 12.0,
+                EIC_ES, 27.0,
+                EIC_PT, 1515.0));
+
+        networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
+
+        Assertions.assertThat(scalingValuesByCountry)
+            .containsEntry(EIC_FR, -1.0)
+            .containsEntry(EIC_ES, 45.0)
+            .containsEntry(EIC_PT, 1515.0);
     }
 }


### PR DESCRIPTION
During the banalcing adjustment process, only move the shift of the two countries concerned by the direction.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
