### PR TITLE
Network shifter: connect transformers for ES & PT scalable generators

### DIFF
--- a/gridcapa-swe-runner-app/pom.xml
+++ b/gridcapa-swe-runner-app/pom.xml
@@ -21,6 +21,16 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <!-- in test classpath, exclude classic powsybl config, so we can use test config -->
+                        <classpathDependencyExclude>com.powsybl:powsybl-config-classic</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -113,10 +123,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-glsk-commons</artifactId>
         </dependency>
         <dependency>
@@ -189,6 +195,11 @@
         <!-- Runtime dependencies -->
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-open-loadflow</artifactId>
             <scope>runtime</scope>
         </dependency>
@@ -197,6 +208,11 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnector.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnector.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.swe.runner.app.dichotomy.shift;
+
+import com.farao_community.farao.commons.EICode;
+import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.modification.scalable.Scalable;
+import com.powsybl.iidm.network.*;
+import org.jgrapht.alg.util.Pair;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Before scaling: fetches scalable generators in ES and PT scalables. For generators connected to the grid through a
+ * transformer, if the transformer is disconnected, connects the transformer.
+ * After scaling: reverts unnecessary changes.
+ *
+ * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
+ */
+public class ScalableGeneratorConnector {
+    private Map<String, GeneratorState> changedGeneratorsInitialState = new HashMap<>();
+    private final ZonalData<Scalable> zonalScalable;
+
+    ScalableGeneratorConnector(ZonalData<Scalable> zonalScalable) {
+        this.zonalScalable = zonalScalable;
+    }
+
+    void prepareForScaling(Network network) throws ShiftingException {
+        changedGeneratorsInitialState = new HashMap<>();
+        connectGeneratorsToMainComponent(network, Country.ES);
+        connectGeneratorsToMainComponent(network, Country.PT);
+    }
+
+    /**
+     * Collects the list of generators of a given country, that are present in the scalable list, but not connected
+     * to the network's main component
+     * For every one of these generators, checks if it has a transformer connecting it to the main component, and
+     * connects it
+     */
+    void connectGeneratorsToMainComponent(Network network, Country country) throws ShiftingException {
+        Set<Generator> generators = zonalScalable.getData(new EICode(country).getAreaCode()).filterInjections(network)
+            .stream()
+            .filter(Generator.class::isInstance)
+            .map(Generator.class::cast)
+            .filter(gen -> gen.getTerminal().getVoltageLevel().getSubstation().isPresent()
+                && gen.getTerminal().getVoltageLevel().getSubstation().get().getCountry().equals(Optional.of(country))
+                && !getBus(gen.getTerminal()).isInMainConnectedComponent()).collect(Collectors.toSet());
+        for (Generator gen : generators) {
+            connectGeneratorTwoWindingsTransformer(gen, network);
+        }
+    }
+
+    /**
+     * Checks if a generator has exactly one transformer connecting it to the main network and connects it.
+     * (If no transformer exist, nothing is modified)
+     * (If more than one transformer exist, TODO)
+     * This method also stores information about the initial state of the generator and its transformer, in order to
+     * revert modifications after scaling, for generators that were not used
+     */
+    private void connectGeneratorTwoWindingsTransformer(Generator generator, Network network) throws ShiftingException {
+        // Store initial targetP for each generator, in order to revert this change after shift,
+        // for the generators that are not connected to main island
+        GeneratorState generatorState = new GeneratorState(generator);
+        changedGeneratorsInitialState.put(generator.getId(), generatorState);
+        if (generatorState.twoWindingsTransformerId != null) {
+            // If generator is connected to network through a transformer, connect it
+            TwoWindingsTransformer twt = network.getTwoWindingsTransformer(generatorState.twoWindingsTransformerId);
+            twt.getTerminal1().connect();
+            twt.getTerminal2().connect();
+        }
+    }
+
+    /**
+     * After scaling, this method resets the initial state of every generator and transformer that were modified by
+     * "connectGeneratorsToMainComponent", if the generator was not used by the scaling (i.e. if it's still not
+     * connected to the main component, or targetP = initTargetP = 0)
+     */
+    void revertUnnecessaryChanges(Network network) {
+        changedGeneratorsInitialState.forEach((genId, initialState) -> {
+            Generator gen = network.getGenerator(genId);
+            if (!getBus(gen.getTerminal()).isInMainConnectedComponent()
+                || (Math.abs(gen.getTargetP()) < 1e-6 && Math.abs(initialState.targetP) < 1e-6)) {
+                // Generator is not connected to the main island, even after connecting it and its TWT
+                // Or it has 0 production and has not moved
+                // Reset it to its state before scaling
+                initialState.apply(network);
+            }
+        });
+    }
+
+    private Bus getBus(Terminal terminal) {
+        return terminal.getBusBreakerView().getConnectableBus();
+    }
+
+    /**
+     * Stores info about the state of the generator and its eventual transformer in the network
+     */
+    private class GeneratorState {
+        String generatorId;
+        double targetP;
+        boolean isTerminalConnected;
+        String twoWindingsTransformerId;
+        Pair<Boolean, Boolean> twtTerminalsConnected;
+
+        GeneratorState(Generator generator) throws ShiftingException {
+            Bus genBus = getBus(generator.getTerminal());
+            if (genBus == null) {
+                throw new ShiftingException(String.format("Unknown terminal bus for generator %s", generator.getId()));
+            }
+            this.generatorId = generator.getId();
+            this.targetP = generator.getTargetP();
+            this.isTerminalConnected = generator.getTerminal().isConnected();
+
+            Set<TwoWindingsTransformer> transformers = new HashSet<>();
+            generator.getTerminal().getVoltageLevel().getTwoWindingsTransformers().forEach(transformers::add);
+
+            for (TwoWindingsTransformer twt : transformers) {
+                if (genBus.equals(getBus(twt.getTerminal1())) || genBus.equals(getBus(twt.getTerminal2()))) {
+                    if (this.twoWindingsTransformerId != null) {
+                        this.twoWindingsTransformerId = null;
+                        this.twtTerminalsConnected = null;
+                        // TODO : we are assuming here that generators linked to grid through multiple transformers
+                        //  should be excluded from scaling. Update this when expected behaviour is clear.
+                    } else {
+                        this.twoWindingsTransformerId = twt.getId();
+                        this.twtTerminalsConnected = Pair.of(twt.getTerminal1().isConnected(), twt.getTerminal2().isConnected());
+                    }
+                }
+            }
+        }
+
+        void apply(Network network) {
+            Generator generator = network.getGenerator(this.generatorId);
+            Objects.requireNonNull(generator);
+            generator.setTargetP(this.targetP);
+            // TODO: the scaling actually does more stuff when connecting the generator (see ConnectGenerator.apply);
+            //  do we have to do the exact opposite when disconnecting?
+            connectTerminal(generator.getTerminal(), this.isTerminalConnected);
+
+            // Some generators are simply connected to the network without a transformer
+            if (twoWindingsTransformerId != null) {
+                TwoWindingsTransformer twoWindingsTransformer = network.getTwoWindingsTransformer(twoWindingsTransformerId);
+                Objects.requireNonNull(twoWindingsTransformer);
+                connectTerminal(twoWindingsTransformer.getTerminal1(), this.twtTerminalsConnected.getFirst());
+                connectTerminal(twoWindingsTransformer.getTerminal2(), this.twtTerminalsConnected.getSecond());
+            }
+        }
+
+        void connectTerminal(Terminal terminal, boolean connect) {
+            if (connect) {
+                terminal.connect();
+            } else {
+                terminal.disconnect();
+            }
+        }
+    }
+}

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnector.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnector.java
@@ -24,17 +24,18 @@ import java.util.stream.Collectors;
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
  */
 public class ScalableGeneratorConnector {
-    private Map<String, GeneratorState> changedGeneratorsInitialState = new HashMap<>();
+    private Map<String, GeneratorState> changedGeneratorsInitialState;
     private final ZonalData<Scalable> zonalScalable;
 
     ScalableGeneratorConnector(ZonalData<Scalable> zonalScalable) {
         this.zonalScalable = zonalScalable;
     }
 
-    void prepareForScaling(Network network) throws ShiftingException {
+    void prepareForScaling(Network network, Set<Country> countriesToProcess) throws ShiftingException {
         changedGeneratorsInitialState = new HashMap<>();
-        connectGeneratorsToMainComponent(network, Country.ES);
-        connectGeneratorsToMainComponent(network, Country.PT);
+        for (Country c : countriesToProcess) {
+            connectGeneratorsToMainComponent(network, c);
+        }
     }
 
     /**

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifter.java
@@ -40,6 +40,7 @@ public final class SweNetworkShifter implements NetworkShifter {
     public static final String ES_FR = "ES_FR";
     private static final double DEFAULT_PMAX = 9999.0;
     private static final double DEFAULT_PMIN = -9999.0;
+    private static final Set<Country> CONNECT_GENERATORS_IN_COUNTRIES = Set.of(Country.ES, Country.PT);
     private final Logger businessLogger;
 
     private final ProcessType processType;
@@ -165,7 +166,7 @@ public final class SweNetworkShifter implements NetworkShifter {
     private void preProcessNetwork(Network network, ScalableGeneratorConnector scalableGeneratorConnector, String initialVariantId, String processedVariantId, String workingVariantCopyId) throws ShiftingException {
         network.getVariantManager().cloneVariant(initialVariantId, processedVariantId, true);
         network.getVariantManager().setWorkingVariant(processedVariantId);
-        scalableGeneratorConnector.prepareForScaling(network);
+        scalableGeneratorConnector.prepareForScaling(network, CONNECT_GENERATORS_IN_COUNTRIES);
         network.getVariantManager().cloneVariant(processedVariantId, workingVariantCopyId, true);
         network.getVariantManager().setWorkingVariant(workingVariantCopyId);
     }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ZonalScalableProvider.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ZonalScalableProvider.java
@@ -42,13 +42,13 @@ public class ZonalScalableProvider {
         String eicFR = new EICode(Country.FR).getAreaCode();
         if (zonalScalable.getData(eicFR) == null) {
             LOGGER.warn("Glsk file does not contains FR scalable for timestamp {}, a Country generators scalable is added", timestamp);
-            Scalable scalableFR = getCountryGeneratorsScalablefoFR(network);
+            Scalable scalableFR = getCountryGeneratorsScalableForFR(network);
             zonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(eicFR, scalableFR)));
         }
         return zonalScalable;
     }
 
-    private Scalable getCountryGeneratorsScalablefoFR(Network network) {
+    private Scalable getCountryGeneratorsScalableForFR(Network network) {
         List<Scalable> scalables = new ArrayList<>();
         List<Float> percentages = new ArrayList<>();
         List<Generator> generators;

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
@@ -25,6 +25,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,7 +46,7 @@ class ScalableGeneratorConnectorTest {
         ZonalData<Scalable> zonalScalable = doc.getZonalScalable(network, instant);
         zonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
         scalableGeneratorConnector = new ScalableGeneratorConnector(zonalScalable);
-        scalableGeneratorConnector.prepareForScaling(network);
+        scalableGeneratorConnector.prepareForScaling(network, Set.of(Country.ES, Country.PT));
     }
 
     private Scalable getCountryGeneratorsScalableForFR(Network network) {

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.swe.runner.app.dichotomy.shift;
+
+import com.farao_community.farao.commons.EICode;
+import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
+import com.powsybl.glsk.cim.CimGlskDocument;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.glsk.commons.ZonalDataImpl;
+import com.powsybl.iidm.modification.scalable.Scalable;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
+ */
+public class ScalableGeneratorConnectorTest {
+    private Network network;
+    private ScalableGeneratorConnector scalableGeneratorConnector;
+
+    @BeforeEach
+    void setUp() throws ShiftingException {
+         network = Network.read("shift/TestCase_with_transformers.xiidm", getClass().getResourceAsStream("/shift/TestCase_with_transformers.xiidm"));
+        CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
+        Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
+        ZonalData<Scalable> zonalScalable = doc.getZonalScalable(network, instant);
+        zonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
+        scalableGeneratorConnector = new ScalableGeneratorConnector(zonalScalable);
+        scalableGeneratorConnector.prepareForScaling(network);
+    }
+
+    private Scalable getCountryGeneratorsScalableForFR(Network network) {
+        List<Scalable> scalables = new ArrayList<>();
+        List<Float> percentages = new ArrayList<>();
+        List<Generator> generators;
+        generators = network.getGeneratorStream()
+            .filter(generator -> Country.FR.equals(generator.getTerminal().getVoltageLevel().getSubstation().map(Substation::getNullableCountry).orElse(null)))
+            .filter(NetworkUtil::isCorrect)
+            .collect(Collectors.toList());
+        //calculate sum P of country's generators
+        double totalCountryP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
+        //calculate factor of each generator
+        generators.forEach(generator -> {
+            float generatorPercentage = (float) (100 * NetworkUtil.pseudoTargetP(generator) / totalCountryP);
+            percentages.add(generatorPercentage);
+            scalables.add(Scalable.onGenerator(generator.getId()));
+        });
+        return Scalable.proportional(percentages, scalables);
+    }
+
+    @Test
+    void tetPrepareForScalingFr() {
+        // Preparation for scaling should have no effect on FR
+        assertFalse(network.getGenerator("FRCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRDDGU1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("FRDDGN1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("FRDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+
+    @Test
+    void tetRevertChangesFr() {
+        scalableGeneratorConnector.revertUnnecessaryChanges(network);
+        // Preparation for scaling should have no effect on FR
+        assertFalse(network.getGenerator("FRCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("FRCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRDDGU1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("FRDDGN1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("FRDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("FRDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+
+    @Test
+    void tetPrepareForScalingEs() {
+        // These generators in merit order are linked to grid through a line that is disconnected: it should remain that way
+        assertFalse(network.getGenerator("ESCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through 2 transformers that are disconnected: they should remain that way
+        assertFalse(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are directly connected to grid: it should remain that way
+        assertTrue(network.getGenerator("ESDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through a transformer that is connected: it should remain that way
+        assertTrue(network.getGenerator("ESCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are directly connected to grid but its terminal is disconnected: it should be reconnected
+        assertTrue(network.getGenerator("ESDDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through a transformer but both are disconnected: they should be reconnected
+        assertTrue(network.getGenerator("ESDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+
+    @Test
+    void tetRevertChangesEs() {
+        scalableGeneratorConnector.revertUnnecessaryChanges(network);
+        assertFalse(network.getGenerator("ESCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESDDGU1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("ESDDGN1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("ESDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+
+    @Test
+    void tetPrepareForScalingPt() {
+        // These generators in merit order are linked to grid through a line that is disconnected: it should remain that way
+        assertFalse(network.getGenerator("PTCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through 2 transformers that are disconnected: they should remain that way
+        assertFalse(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are directly connected to grid: it should remain that way
+        assertTrue(network.getGenerator("PTDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through a transformer that is connected: it should remain that way
+        assertTrue(network.getGenerator("PTCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are directly connected to grid but its terminal is disconnected: it should be reconnected
+        assertTrue(network.getGenerator("PTDDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through a transformer but both are disconnected: they should be reconnected
+        assertTrue(network.getGenerator("PTDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+
+    @Test
+    void tetRevertChangesPt() {
+        scalableGeneratorConnector.revertUnnecessaryChanges(network);
+        assertFalse(network.getGenerator("PTCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTDDGU1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("PTDDGN1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("PTDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+
+    @Test
+    void testRevertOnlyUnnecessaryChanges() {
+        network.getGenerator("ESDDGU1 _generator").getTerminal().connect();
+        network.getGenerator("ESDDGU1 _generator").setTargetP(100.);
+
+        network.getGenerator("ESDTGN1 _generator").getTerminal().connect();
+        network.getGenerator("ESDTGN1 _generator").setTargetP(10.);
+
+        network.getGenerator("PTDTGU1 _generator").getTerminal().connect();
+        network.getGenerator("PTDTGU1 _generator").setTargetP(10.);
+
+        scalableGeneratorConnector.revertUnnecessaryChanges(network);
+
+        assertFalse(network.getGenerator("ESCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDDGU1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("ESDDGN1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("ESDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+
+        assertFalse(network.getGenerator("PTCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTDDGU1 _generator").getTerminal().isConnected());
+        assertFalse(network.getGenerator("PTDDGN1 _generator").getTerminal().isConnected());
+        assertTrue(network.getGenerator("PTDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertFalse(network.getGenerator("PTDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+    }
+}

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
  */
-public class ScalableGeneratorConnectorTest {
+class ScalableGeneratorConnectorTest {
     private Network network;
     private ScalableGeneratorConnector scalableGeneratorConnector;
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
@@ -39,7 +39,7 @@ public class ScalableGeneratorConnectorTest {
 
     @BeforeEach
     void setUp() throws ShiftingException {
-         network = Network.read("shift/TestCase_with_transformers.xiidm", getClass().getResourceAsStream("/shift/TestCase_with_transformers.xiidm"));
+        network = Network.read("shift/TestCase_with_transformers.xiidm", getClass().getResourceAsStream("/shift/TestCase_with_transformers.xiidm"));
         CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
         Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
         ZonalData<Scalable> zonalScalable = doc.getZonalScalable(network, instant);

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/ScalableGeneratorConnectorTest.java
@@ -108,16 +108,16 @@ class ScalableGeneratorConnectorTest {
         // These generators in merit order are linked to grid through a line that is disconnected: it should remain that way
         assertFalse(network.getGenerator("ESCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertFalse(network.getGenerator("ESCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        // These generators are connected to grid through 2 transformers that are disconnected: they should remain that way
-        assertFalse(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        assertFalse(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through 2 transformers that are disconnected: they should be reconnected
+        assertTrue(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         // These generators are directly connected to grid: it should remain that way
         assertTrue(network.getGenerator("ESDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertTrue(network.getGenerator("ESDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         // These generators are connected to grid through a transformer that is connected: it should remain that way
         assertTrue(network.getGenerator("ESCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertTrue(network.getGenerator("ESCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        // These generators are directly connected to grid but its terminal is disconnected: it should be reconnected
+        // These generators are directly connected to grid but its terminal is disconnected: they should be reconnected
         assertTrue(network.getGenerator("ESDDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertTrue(network.getGenerator("ESDDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         // These generators are connected to grid through a transformer but both are disconnected: they should be reconnected
@@ -147,9 +147,9 @@ class ScalableGeneratorConnectorTest {
         // These generators in merit order are linked to grid through a line that is disconnected: it should remain that way
         assertFalse(network.getGenerator("PTCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertFalse(network.getGenerator("PTCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        // These generators are connected to grid through 2 transformers that are disconnected: they should remain that way
-        assertFalse(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        assertFalse(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        // These generators are connected to grid through 2 transformers that are disconnected: they should be reconnected
+        assertTrue(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertTrue(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         // These generators are directly connected to grid: it should remain that way
         assertTrue(network.getGenerator("PTDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertTrue(network.getGenerator("PTDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
@@ -29,7 +29,9 @@ import org.slf4j.Logger;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
@@ -6,15 +6,21 @@
  */
 package com.farao_community.farao.swe.runner.app.dichotomy.shift;
 
+import com.farao_community.farao.commons.EICode;
 import com.farao_community.farao.dichotomy.api.exceptions.GlskLimitationException;
 import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
 import com.farao_community.farao.dichotomy.shift.ShiftDispatcher;
 import com.farao_community.farao.swe.runner.api.resource.ProcessType;
 import com.farao_community.farao.swe.runner.app.configurations.ProcessConfiguration;
 import com.farao_community.farao.swe.runner.app.dichotomy.DichotomyDirection;
+import com.powsybl.glsk.cim.CimGlskDocument;
+import com.powsybl.glsk.commons.ZonalData;
 import com.powsybl.glsk.commons.ZonalDataImpl;
 import com.powsybl.iidm.modification.scalable.Scalable;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,11 +29,11 @@ import org.slf4j.Logger;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.time.*;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Mohamed Ben-rejeb {@literal <mohamed.ben-rejeb at rte-france.com>}
@@ -38,6 +44,7 @@ class SweNetworkShifterTest {
     private static final String EIC_FR = "10YFR-RTE------C";
     private static final String EIC_ES = "10YES-REE------0";
     private static final String EIC_PT = "10YPT-REN------W";
+    private static final Double TARGET_P_TOLERANCE = 1e-3;
 
     @MockBean
     private ProcessConfiguration processConfiguration;
@@ -280,5 +287,130 @@ class SweNetworkShifterTest {
             .containsEntry(EIC_FR, -1.0)
             .containsEntry(EIC_ES, 45.0)
             .containsEntry(EIC_PT, 1515.0);
+    }
+
+    @Test
+    void testConnectGeneratorsEs() throws GlskLimitationException, ShiftingException {
+        Network network = Network.read("shift/TestCase_with_transformers.xiidm", getClass().getResourceAsStream("/shift/TestCase_with_transformers.xiidm"));
+        CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
+        Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
+        ZonalData<Scalable> zonalScalable = doc.getZonalScalable(network, instant);
+        zonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
+        Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+            DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration);
+        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(20);
+        sweNetworkShifter.shiftNetwork(800., network);
+
+        assertEquals(Set.of("InitialState"), network.getVariantManager().getVariantIds());
+        Map<String, Double> shiftedExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);
+        assertEquals(800., shiftedExchanges.get("ES_FR"), 1.);
+        assertEquals(0., shiftedExchanges.get("ES_PT"), 1.);
+        // 1st generator in merit order is linked to grid through a line that is disconnected: it should remain that way and targetP remain at 0
+        assertFalse(network.getGenerator("ESCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("ESCDGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 2nd generator is connected to grid through 2 transformers that are disconnected: they should remain that way and targetP remain at 0
+        assertFalse(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("ESD2GU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 3rd generator is directly connected to grid: it should remain that way and targetP set to 1200 (its max)
+        assertTrue(network.getGenerator("ESDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1200., network.getGenerator("ESDCGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 4th generator is connected to grid through a transformer that is connected: it should remain that way and targetP set to 1200 (its max)
+        assertTrue(network.getGenerator("ESCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1200., network.getGenerator("ESCTGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 5th generator is directly connected to grid but its terminal is disconnected: it should be reconnected and targetP set to 200 (its max)
+        assertTrue(network.getGenerator("ESDDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(200., network.getGenerator("ESDDGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 6th generator is connected to grid through a transformer but both are disconnected: they should be reconnected and
+        // targetP set to 200 (to reach the 800MW) + some more to compensate for losses
+        assertTrue(network.getGenerator("ESDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(227., network.getGenerator("ESDTGU1 _generator").getTargetP(), 2.);
+        // +800MW is already reached, the rest of the generators should not be changed nor scaled
+        assertFalse(network.getGenerator("ESCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("ESCDGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertFalse(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("ESD2GN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertTrue(network.getGenerator("ESDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1000., network.getGenerator("ESDCGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertTrue(network.getGenerator("ESCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1000., network.getGenerator("ESCTGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertFalse(network.getGenerator("ESDDGN1 _generator").getTerminal().isConnected());
+        assertEquals(0., network.getGenerator("ESDDGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertFalse(network.getGenerator("ESDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("ESDTGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+    }
+
+    @Test
+    void testConnectGeneratorsPt() throws GlskLimitationException, ShiftingException {
+        // Same test as above but in the PR->ES direction
+        Network network = Network.read("shift/TestCase_with_transformers.xiidm", getClass().getResourceAsStream("/shift/TestCase_with_transformers.xiidm"));
+
+        CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
+        Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
+        ZonalData<Scalable> zonalScalable = doc.getZonalScalable(network, instant);
+        zonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
+        Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.PT_ES, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+            DichotomyDirection.PT_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration);
+        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(20);
+        sweNetworkShifter.shiftNetwork(800., network);
+
+        assertEquals(Set.of("InitialState"), network.getVariantManager().getVariantIds());
+        Map<String, Double> shiftedExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);
+        assertEquals(-800., shiftedExchanges.get("ES_PT"), 1.);
+        assertEquals(0., shiftedExchanges.get("ES_FR"), 1.);
+        // 1st generator in merit order is linked to grid through a line that is disconnected: it should remain that way and targetP remain at 0
+        assertFalse(network.getGenerator("PTCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("PTCDGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 2nd generator is connected to grid through 2 transformers that are disconnected: they should remain that way and targetP remain at 0
+        assertFalse(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("PTD2GU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 3rd generator is directly connected to grid: it should remain that way and targetP set to 1200 (its max)
+        assertTrue(network.getGenerator("PTDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1200., network.getGenerator("PTDCGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 4th generator is connected to grid through a transformer that is connected: it should remain that way and targetP set to 1200 (its max)
+        assertTrue(network.getGenerator("PTCTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1200., network.getGenerator("PTCTGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 5th generator is directly connected to grid but its terminal is disconnected: it should be reconnected and targetP set to 200 (its max)
+        assertTrue(network.getGenerator("PTDDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(200., network.getGenerator("PTDDGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 6th generator is connected to grid through a transformer but both are disconnected: they should be reconnected and
+        // targetP set to 200 (to reach the 800MW) + some more to compensate for losses
+        assertTrue(network.getGenerator("PTDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(227., network.getGenerator("PTDTGU1 _generator").getTargetP(), 2.);
+        // +800MW is already reached, the rest of the generators should not be changed nor scaled
+        assertFalse(network.getGenerator("PTCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("PTCDGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertFalse(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("PTD2GN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertTrue(network.getGenerator("PTDCGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1000., network.getGenerator("PTDCGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertTrue(network.getGenerator("PTCTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(1000., network.getGenerator("PTCTGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertFalse(network.getGenerator("PTDDGN1 _generator").getTerminal().isConnected());
+        assertEquals(0., network.getGenerator("PTDDGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        assertFalse(network.getGenerator("PTDTGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(0., network.getGenerator("PTDTGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+    }
+
+    private Scalable getCountryGeneratorsScalableForFR(Network network) {
+        List<Scalable> scalables = new ArrayList<>();
+        List<Float> percentages = new ArrayList<>();
+        List<Generator> generators;
+        generators = network.getGeneratorStream()
+            .filter(generator -> Country.FR.equals(generator.getTerminal().getVoltageLevel().getSubstation().map(Substation::getNullableCountry).orElse(null)))
+            .filter(NetworkUtil::isCorrect)
+            .collect(Collectors.toList());
+        //calculate sum P of country's generators
+        double totalCountryP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
+        //calculate factor of each generator
+        generators.forEach(generator -> {
+            float generatorPercentage = (float) (100 * NetworkUtil.pseudoTargetP(generator) / totalCountryP);
+            percentages.add(generatorPercentage);
+            scalables.add(Scalable.onGenerator(generator.getId()));
+        });
+        return Scalable.proportional(percentages, scalables);
     }
 }

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
@@ -300,7 +300,7 @@ class SweNetworkShifterTest {
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
             DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration);
-        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(20);
+        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(800., network);
 
         assertEquals(Set.of("InitialState"), network.getVariantManager().getVariantIds());
@@ -354,7 +354,7 @@ class SweNetworkShifterTest {
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.PT_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
             DichotomyDirection.PT_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration);
-        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(20);
+        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(800., network);
 
         assertEquals(Set.of("InitialState"), network.getVariantManager().getVariantIds());

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/shift/SweNetworkShifterTest.java
@@ -303,18 +303,18 @@ class SweNetworkShifterTest {
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
             DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
-        sweNetworkShifter.shiftNetwork(800., network);
+        sweNetworkShifter.shiftNetwork(1000., network);
 
         assertEquals(Set.of("InitialState"), network.getVariantManager().getVariantIds());
         Map<String, Double> shiftedExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);
-        assertEquals(800., shiftedExchanges.get("ES_FR"), 1.);
+        assertEquals(1000., shiftedExchanges.get("ES_FR"), 1.);
         assertEquals(0., shiftedExchanges.get("ES_PT"), 1.);
         // 1st generator in merit order is linked to grid through a line that is disconnected: it should remain that way and targetP remain at 0
         assertFalse(network.getGenerator("ESCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertEquals(0., network.getGenerator("ESCDGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
-        // 2nd generator is connected to grid through 2 transformers that are disconnected: they should remain that way and targetP remain at 0
-        assertFalse(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        assertEquals(0., network.getGenerator("ESD2GU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 2nd generator is connected to grid through 2 transformers that are disconnected: it should be reconnected and targetP set to 200 (its max)
+        assertTrue(network.getGenerator("ESD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(200., network.getGenerator("ESD2GU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
         // 3rd generator is directly connected to grid: it should remain that way and targetP set to 1200 (its max)
         assertTrue(network.getGenerator("ESDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertEquals(1200., network.getGenerator("ESDCGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
@@ -327,8 +327,8 @@ class SweNetworkShifterTest {
         // 6th generator is connected to grid through a transformer but both are disconnected: they should be reconnected and
         // targetP set to 200 (to reach the 800MW) + some more to compensate for losses
         assertTrue(network.getGenerator("ESDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        assertEquals(227., network.getGenerator("ESDTGU1 _generator").getTargetP(), 2.);
-        // +800MW is already reached, the rest of the generators should not be changed nor scaled
+        assertEquals(233., network.getGenerator("ESDTGU1 _generator").getTargetP(), 2.);
+        // +1000MW is already reached, the rest of the generators should not be changed nor scaled
         assertFalse(network.getGenerator("ESCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertEquals(0., network.getGenerator("ESCDGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
         assertFalse(network.getGenerator("ESD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
@@ -357,18 +357,18 @@ class SweNetworkShifterTest {
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
             DichotomyDirection.PT_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
-        sweNetworkShifter.shiftNetwork(800., network);
+        sweNetworkShifter.shiftNetwork(1000., network);
 
         assertEquals(Set.of("InitialState"), network.getVariantManager().getVariantIds());
         Map<String, Double> shiftedExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);
-        assertEquals(-800., shiftedExchanges.get("ES_PT"), 1.);
+        assertEquals(-1000., shiftedExchanges.get("ES_PT"), 1.);
         assertEquals(0., shiftedExchanges.get("ES_FR"), 1.);
         // 1st generator in merit order is linked to grid through a line that is disconnected: it should remain that way and targetP remain at 0
         assertFalse(network.getGenerator("PTCDGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertEquals(0., network.getGenerator("PTCDGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
-        // 2nd generator is connected to grid through 2 transformers that are disconnected: they should remain that way and targetP remain at 0
-        assertFalse(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        assertEquals(0., network.getGenerator("PTD2GU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
+        // 2nd generator is connected to grid through 2 transformers that are disconnected: it should be reconnected and targetP set to 200 (its max)
+        assertTrue(network.getGenerator("PTD2GU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
+        assertEquals(200., network.getGenerator("PTD2GU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
         // 3rd generator is directly connected to grid: it should remain that way and targetP set to 1200 (its max)
         assertTrue(network.getGenerator("PTDCGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertEquals(1200., network.getGenerator("PTDCGU1 _generator").getTargetP(), TARGET_P_TOLERANCE);
@@ -381,8 +381,8 @@ class SweNetworkShifterTest {
         // 6th generator is connected to grid through a transformer but both are disconnected: they should be reconnected and
         // targetP set to 200 (to reach the 800MW) + some more to compensate for losses
         assertTrue(network.getGenerator("PTDTGU1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
-        assertEquals(227., network.getGenerator("PTDTGU1 _generator").getTargetP(), 2.);
-        // +800MW is already reached, the rest of the generators should not be changed nor scaled
+        assertEquals(233., network.getGenerator("PTDTGU1 _generator").getTargetP(), 2.);
+        // +1000MW is already reached, the rest of the generators should not be changed nor scaled
         assertFalse(network.getGenerator("PTCDGN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());
         assertEquals(0., network.getGenerator("PTCDGN1 _generator").getTargetP(), TARGET_P_TOLERANCE);
         assertFalse(network.getGenerator("PTD2GN1 _generator").getTerminal().getBusBreakerView().getConnectableBus().isInMainSynchronousComponent());

--- a/gridcapa-swe-runner-app/src/test/resources/com/powsybl/config/test/config.yml
+++ b/gridcapa-swe-runner-app/src/test/resources/com/powsybl/config/test/config.yml
@@ -1,0 +1,14 @@
+load-flow-default-parameters:
+  voltageInitMode: DC_VALUES
+  balanceType: PROPORTIONAL_TO_GENERATION_P
+  countriesToBalance: AL,AT,BA,BE,BG,CH,CZ,DE,ES,FR,GR,HR,HU,IT,ME,MK,NL,PL,PT,RO,RS,SI,SK,UA
+  phaseShifterRegulationOn: true
+
+open-loadflow-default-parameters:
+  minPlausibleTargetVoltage: 0.5
+  maxPlausibleTargetVoltage: 1.5
+  plausibleActivePowerLimit: 10000
+  maxIteration: 100
+  newtonRaphsonConvEpsPerEq: 1.0E-3
+  minRealisticVoltage : 0.5
+  maxRealisticVoltage : 1.5

--- a/gridcapa-swe-runner-app/src/test/resources/com/powsybl/config/test/filelist.txt
+++ b/gridcapa-swe-runner-app/src/test/resources/com/powsybl/config/test/filelist.txt
@@ -1,0 +1,1 @@
+config.yml

--- a/gridcapa-swe-runner-app/src/test/resources/shift/TestCase_with_transformers.xiidm
+++ b/gridcapa-swe-runner-app/src/test/resources/shift/TestCase_with_transformers.xiidm
@@ -1,0 +1,1433 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_10" id="shift/TestCase_with_transformers" caseDate="2023-08-25T17:35:29.641+02:00" forecastDistance="0" sourceFormat="UCTE" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="ES_L1_" country="ES">
+        <iidm:voltageLevel id="ES_L1_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_L1_1 ">
+                    <iidm:property name="geographicalName" value="ES_L1_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_L1_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_L1_1 " connectableBus="ES_L1_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ES_L1_1 _load" loadType="UNDEFINED" p0="1967.0" q0="-53.5" bus="ES_L1_1 " connectableBus="ES_L1_1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ES_L2_" country="ES">
+        <iidm:voltageLevel id="ES_L2_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_L2_1 ">
+                    <iidm:property name="geographicalName" value="ES_L2_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_L2_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_L2_1 " connectableBus="ES_L2_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ES_L2_1 _load" loadType="UNDEFINED" p0="1967.0" q0="-53.5" bus="ES_L2_1 " connectableBus="ES_L2_1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ES_E1_" country="ES">
+        <iidm:voltageLevel id="ES_E1_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_E1_1 ">
+                    <iidm:property name="geographicalName" value="ES_E1_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_E1_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_E1_1 " connectableBus="ES_E1_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ES_01_" country="ES">
+        <iidm:voltageLevel id="ES_01_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_01_1 ">
+                    <iidm:property name="geographicalName" value="ES_01_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_01_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_01_1 " connectableBus="ES_01_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ES_02_" country="ES">
+        <iidm:voltageLevel id="ES_02_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_02_1 ">
+                    <iidm:property name="geographicalName" value="ES_02_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_02_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_02_1 " connectableBus="ES_02_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESCTGN" country="ES">
+        <iidm:voltageLevel id="ESCTGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESCTGN1 ">
+                    <iidm:property name="geographicalName" value="ESCTGN1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_03_1 ">
+                    <iidm:property name="geographicalName" value="ES_03_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESCTGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="ESCTGN1 " connectableBus="ESCTGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_03_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_03_1 " connectableBus="ES_03_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESCTGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESCTGN1 " connectableBus="ESCTGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_03_1  ESCTGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="ESCTGN1 " connectableBus1="ESCTGN1 " voltageLevelId1="ESCTGN1" bus2="ES_03_1 " connectableBus2="ES_03_1 " voltageLevelId2="ESCTGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ESCTGU" country="ES">
+        <iidm:voltageLevel id="ESCTGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESCTGU1 ">
+                    <iidm:property name="geographicalName" value="ESCTGU1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_04_1 ">
+                    <iidm:property name="geographicalName" value="ES_04_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESCTGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="ESCTGU1 " connectableBus="ESCTGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_04_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_04_1 " connectableBus="ES_04_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESCTGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESCTGU1 " connectableBus="ESCTGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_04_1  ESCTGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="ESCTGU1 " connectableBus1="ESCTGU1 " voltageLevelId1="ESCTGU1" bus2="ES_04_1 " connectableBus2="ES_04_1 " voltageLevelId2="ESCTGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ES_05_" country="ES">
+        <iidm:voltageLevel id="ES_05_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_05_1 ">
+                    <iidm:property name="geographicalName" value="ES_05_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_05_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_05_1 " connectableBus="ES_05_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ES_06_" country="ES">
+        <iidm:voltageLevel id="ES_06_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_06_1 ">
+                    <iidm:property name="geographicalName" value="ES_06_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_06_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_06_1 " connectableBus="ES_06_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESDTGN" country="ES">
+        <iidm:voltageLevel id="ESDTGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESDTGN1 ">
+                    <iidm:property name="geographicalName" value="ESDTGN1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_07_1 ">
+                    <iidm:property name="geographicalName" value="ES_07_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESDTGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESDTGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_07_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_07_1 " connectableBus="ES_07_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESDTGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESDTGN1 " connectableBus="ESDTGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_07_1  ESDTGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESDTGN1 " voltageLevelId1="ESDTGN1" connectableBus2="ES_07_1 " voltageLevelId2="ESDTGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ESDTGU" country="ES">
+        <iidm:voltageLevel id="ESDTGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESDTGU1 ">
+                    <iidm:property name="geographicalName" value="ESDTGU1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_08_1 ">
+                    <iidm:property name="geographicalName" value="ES_08_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESDTGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESDTGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_08_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_08_1 " connectableBus="ES_08_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESDTGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESDTGU1 " connectableBus="ESDTGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_08_1  ESDTGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESDTGU1 " voltageLevelId1="ESDTGU1" connectableBus2="ES_08_1 " voltageLevelId2="ESDTGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ESD2GN" country="ES">
+        <iidm:voltageLevel id="ESD2GN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESD2GN1 ">
+                    <iidm:property name="geographicalName" value="ESD2GN1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_09_1 ">
+                    <iidm:property name="geographicalName" value="ES_09_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESD2GN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESD2GN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_09_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_09_1 " connectableBus="ES_09_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESD2GN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESD2GN1 " connectableBus="ESD2GN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_09_1  ESD2GN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESD2GN1 " voltageLevelId1="ESD2GN1" connectableBus2="ES_09_1 " voltageLevelId2="ESD2GN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="ES_09_1  ESD2GN1  2" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESD2GN1 " voltageLevelId1="ESD2GN1" connectableBus2="ES_09_1 " voltageLevelId2="ESD2GN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ESD2GU" country="ES">
+        <iidm:voltageLevel id="ESD2GU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESD2GU1 ">
+                    <iidm:property name="geographicalName" value="ESD2GU1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_10_1 ">
+                    <iidm:property name="geographicalName" value="ES_10_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESD2GU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESD2GU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_10_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_10_1 " connectableBus="ES_10_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESD2GU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESD2GU1 " connectableBus="ESD2GU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_10_1  ESD2GU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESD2GU1 " voltageLevelId1="ESD2GU1" connectableBus2="ES_10_1 " voltageLevelId2="ESD2GU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="ES_10_1  ESD2GU1  2" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESD2GU1 " voltageLevelId1="ESD2GU1" connectableBus2="ES_10_1 " voltageLevelId2="ESD2GU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ES_11_" country="ES">
+        <iidm:voltageLevel id="ES_11_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_11_1 ">
+                    <iidm:property name="geographicalName" value="ES_11_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_11_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_11_1 " connectableBus="ES_11_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESCDGN" country="ES">
+        <iidm:voltageLevel id="ESCDGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESCDGN1 ">
+                    <iidm:property name="geographicalName" value="ESCDGN1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_12_1 ">
+                    <iidm:property name="geographicalName" value="ES_12_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESCDGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESCDGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_12_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_12_1 " connectableBus="ES_12_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESCDGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESCDGN1 " connectableBus="ESCDGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_12_1  ESCDGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESCDGN1 " voltageLevelId1="ESCDGN1" connectableBus2="ES_12_1 " voltageLevelId2="ESCDGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ES_13_" country="ES">
+        <iidm:voltageLevel id="ES_13_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ES_13_1 ">
+                    <iidm:property name="geographicalName" value="ES_13_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ES_13_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_13_1 " connectableBus="ES_13_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESCDGU" country="ES">
+        <iidm:voltageLevel id="ESCDGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESCDGU1 ">
+                    <iidm:property name="geographicalName" value="ESCDGU1"/>
+                </iidm:bus>
+                <iidm:bus id="ES_14_1 ">
+                    <iidm:property name="geographicalName" value="ES_14_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESCDGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESCDGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="ES_14_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="ES_14_1 " connectableBus="ES_14_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESCDGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESCDGU1 " connectableBus="ESCDGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="ES_14_1  ESCDGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="ESCDGU1 " voltageLevelId1="ESCDGU1" connectableBus2="ES_14_1 " voltageLevelId2="ESCDGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="ESDCGU" country="ES">
+        <iidm:voltageLevel id="ESDCGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESDCGU1 ">
+                    <iidm:property name="geographicalName" value="ESDCGU1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESDCGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="ESDCGU1 " connectableBus="ESDCGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESDCGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESDCGU1 " connectableBus="ESDCGU1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESDCGN" country="ES">
+        <iidm:voltageLevel id="ESDCGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESDCGN1 ">
+                    <iidm:property name="geographicalName" value="ESDCGN1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESDCGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="ESDCGN1 " connectableBus="ESDCGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESDCGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESDCGN1 " connectableBus="ESDCGN1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESDDGU" country="ES">
+        <iidm:voltageLevel id="ESDDGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESDDGU1 ">
+                    <iidm:property name="geographicalName" value="ESDDGU1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESDDGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESDDGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESDDGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESDDGU1 " connectableBus="ESDDGU1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ESDDGN" country="ES">
+        <iidm:voltageLevel id="ESDDGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ESDDGN1 ">
+                    <iidm:property name="geographicalName" value="ESDDGN1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ESDDGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="ESDDGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ESDDGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="ESDDGN1 " connectableBus="ESDDGN1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FR_L1_" country="FR">
+        <iidm:voltageLevel id="FR_L1_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_L1_1 ">
+                    <iidm:property name="geographicalName" value="FR_L1_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_L1_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_L1_1 " connectableBus="FR_L1_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FR_L1_1 _load" loadType="UNDEFINED" p0="1967.0" q0="-53.5" bus="FR_L1_1 " connectableBus="FR_L1_1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FR_L2_" country="FR">
+        <iidm:voltageLevel id="FR_L2_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_L2_1 ">
+                    <iidm:property name="geographicalName" value="FR_L2_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_L2_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_L2_1 " connectableBus="FR_L2_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FR_L2_1 _load" loadType="UNDEFINED" p0="1967.0" q0="-53.5" bus="FR_L2_1 " connectableBus="FR_L2_1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FR_E1_" country="FR">
+        <iidm:voltageLevel id="FR_E1_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_E1_1 ">
+                    <iidm:property name="geographicalName" value="FR_E1_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_E1_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_E1_1 " connectableBus="FR_E1_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FR_01_" country="FR">
+        <iidm:voltageLevel id="FR_01_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_01_1 ">
+                    <iidm:property name="geographicalName" value="FR_01_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_01_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_01_1 " connectableBus="FR_01_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FR_02_" country="FR">
+        <iidm:voltageLevel id="FR_02_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_02_1 ">
+                    <iidm:property name="geographicalName" value="FR_02_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_02_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_02_1 " connectableBus="FR_02_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRCTGN" country="FR">
+        <iidm:voltageLevel id="FRCTGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRCTGN1 ">
+                    <iidm:property name="geographicalName" value="FRCTGN1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_03_1 ">
+                    <iidm:property name="geographicalName" value="FR_03_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRCTGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="FRCTGN1 " connectableBus="FRCTGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_03_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_03_1 " connectableBus="FR_03_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRCTGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRCTGN1 " connectableBus="FRCTGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_03_1  FRCTGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="FRCTGN1 " connectableBus1="FRCTGN1 " voltageLevelId1="FRCTGN1" bus2="FR_03_1 " connectableBus2="FR_03_1 " voltageLevelId2="FRCTGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FRCTGU" country="FR">
+        <iidm:voltageLevel id="FRCTGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRCTGU1 ">
+                    <iidm:property name="geographicalName" value="FRCTGU1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_04_1 ">
+                    <iidm:property name="geographicalName" value="FR_04_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRCTGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="FRCTGU1 " connectableBus="FRCTGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_04_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_04_1 " connectableBus="FR_04_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRCTGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRCTGU1 " connectableBus="FRCTGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_04_1  FRCTGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="FRCTGU1 " connectableBus1="FRCTGU1 " voltageLevelId1="FRCTGU1" bus2="FR_04_1 " connectableBus2="FR_04_1 " voltageLevelId2="FRCTGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FR_05_" country="FR">
+        <iidm:voltageLevel id="FR_05_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_05_1 ">
+                    <iidm:property name="geographicalName" value="FR_05_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_05_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_05_1 " connectableBus="FR_05_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FR_06_" country="FR">
+        <iidm:voltageLevel id="FR_06_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_06_1 ">
+                    <iidm:property name="geographicalName" value="FR_06_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_06_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_06_1 " connectableBus="FR_06_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRDTGN" country="FR">
+        <iidm:voltageLevel id="FRDTGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRDTGN1 ">
+                    <iidm:property name="geographicalName" value="FRDTGN1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_07_1 ">
+                    <iidm:property name="geographicalName" value="FR_07_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRDTGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRDTGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_07_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_07_1 " connectableBus="FR_07_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRDTGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRDTGN1 " connectableBus="FRDTGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_07_1  FRDTGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRDTGN1 " voltageLevelId1="FRDTGN1" connectableBus2="FR_07_1 " voltageLevelId2="FRDTGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FRDTGU" country="FR">
+        <iidm:voltageLevel id="FRDTGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRDTGU1 ">
+                    <iidm:property name="geographicalName" value="FRDTGU1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_08_1 ">
+                    <iidm:property name="geographicalName" value="FR_08_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRDTGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRDTGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_08_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_08_1 " connectableBus="FR_08_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRDTGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRDTGU1 " connectableBus="FRDTGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_08_1  FRDTGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRDTGU1 " voltageLevelId1="FRDTGU1" connectableBus2="FR_08_1 " voltageLevelId2="FRDTGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FRD2GN" country="FR">
+        <iidm:voltageLevel id="FRD2GN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRD2GN1 ">
+                    <iidm:property name="geographicalName" value="FRD2GN1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_09_1 ">
+                    <iidm:property name="geographicalName" value="FR_09_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRD2GN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRD2GN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_09_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_09_1 " connectableBus="FR_09_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRD2GN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRD2GN1 " connectableBus="FRD2GN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_09_1  FRD2GN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRD2GN1 " voltageLevelId1="FRD2GN1" connectableBus2="FR_09_1 " voltageLevelId2="FRD2GN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="FR_09_1  FRD2GN1  2" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRD2GN1 " voltageLevelId1="FRD2GN1" connectableBus2="FR_09_1 " voltageLevelId2="FRD2GN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FRD2GU" country="FR">
+        <iidm:voltageLevel id="FRD2GU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRD2GU1 ">
+                    <iidm:property name="geographicalName" value="FRD2GU1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_10_1 ">
+                    <iidm:property name="geographicalName" value="FR_10_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRD2GU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRD2GU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_10_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_10_1 " connectableBus="FR_10_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRD2GU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRD2GU1 " connectableBus="FRD2GU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_10_1  FRD2GU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRD2GU1 " voltageLevelId1="FRD2GU1" connectableBus2="FR_10_1 " voltageLevelId2="FRD2GU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="FR_10_1  FRD2GU1  2" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRD2GU1 " voltageLevelId1="FRD2GU1" connectableBus2="FR_10_1 " voltageLevelId2="FRD2GU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FR_11_" country="FR">
+        <iidm:voltageLevel id="FR_11_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_11_1 ">
+                    <iidm:property name="geographicalName" value="FR_11_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_11_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_11_1 " connectableBus="FR_11_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRCDGN" country="FR">
+        <iidm:voltageLevel id="FRCDGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRCDGN1 ">
+                    <iidm:property name="geographicalName" value="FRCDGN1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_12_1 ">
+                    <iidm:property name="geographicalName" value="FR_12_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRCDGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRCDGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_12_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_12_1 " connectableBus="FR_12_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRCDGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRCDGN1 " connectableBus="FRCDGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_12_1  FRCDGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRCDGN1 " voltageLevelId1="FRCDGN1" connectableBus2="FR_12_1 " voltageLevelId2="FRCDGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FR_13_" country="FR">
+        <iidm:voltageLevel id="FR_13_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FR_13_1 ">
+                    <iidm:property name="geographicalName" value="FR_13_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FR_13_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_13_1 " connectableBus="FR_13_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRCDGU" country="FR">
+        <iidm:voltageLevel id="FRCDGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRCDGU1 ">
+                    <iidm:property name="geographicalName" value="FRCDGU1"/>
+                </iidm:bus>
+                <iidm:bus id="FR_14_1 ">
+                    <iidm:property name="geographicalName" value="FR_14_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRCDGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRCDGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FR_14_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="FR_14_1 " connectableBus="FR_14_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRCDGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRCDGU1 " connectableBus="FRCDGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FR_14_1  FRCDGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="FRCDGU1 " voltageLevelId1="FRCDGU1" connectableBus2="FR_14_1 " voltageLevelId2="FRCDGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FRDCGU" country="FR">
+        <iidm:voltageLevel id="FRDCGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRDCGU1 ">
+                    <iidm:property name="geographicalName" value="FRDCGU1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRDCGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="FRDCGU1 " connectableBus="FRDCGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRDCGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRDCGU1 " connectableBus="FRDCGU1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRDCGN" country="FR">
+        <iidm:voltageLevel id="FRDCGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRDCGN1 ">
+                    <iidm:property name="geographicalName" value="FRDCGN1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRDCGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="FRDCGN1 " connectableBus="FRDCGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRDCGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRDCGN1 " connectableBus="FRDCGN1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRDDGU" country="FR">
+        <iidm:voltageLevel id="FRDDGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRDDGU1 ">
+                    <iidm:property name="geographicalName" value="FRDDGU1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRDDGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRDDGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRDDGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRDDGU1 " connectableBus="FRDDGU1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRDDGN" country="FR">
+        <iidm:voltageLevel id="FRDDGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRDDGN1 ">
+                    <iidm:property name="geographicalName" value="FRDDGN1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRDDGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="FRDDGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FRDDGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="FRDDGN1 " connectableBus="FRDDGN1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PT_L1_" country="PT">
+        <iidm:voltageLevel id="PT_L1_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_L1_1 ">
+                    <iidm:property name="geographicalName" value="PT_L1_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_L1_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_L1_1 " connectableBus="PT_L1_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PT_L1_1 _load" loadType="UNDEFINED" p0="1967.0" q0="-53.5" bus="PT_L1_1 " connectableBus="PT_L1_1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PT_L2_" country="PT">
+        <iidm:voltageLevel id="PT_L2_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_L2_1 ">
+                    <iidm:property name="geographicalName" value="PT_L2_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_L2_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_L2_1 " connectableBus="PT_L2_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PT_L2_1 _load" loadType="UNDEFINED" p0="1967.0" q0="-53.5" bus="PT_L2_1 " connectableBus="PT_L2_1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PT_E1_" country="PT">
+        <iidm:voltageLevel id="PT_E1_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_E1_1 ">
+                    <iidm:property name="geographicalName" value="PT_E1_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_E1_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_E1_1 " connectableBus="PT_E1_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PT_01_" country="PT">
+        <iidm:voltageLevel id="PT_01_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_01_1 ">
+                    <iidm:property name="geographicalName" value="PT_01_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_01_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_01_1 " connectableBus="PT_01_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PT_02_" country="PT">
+        <iidm:voltageLevel id="PT_02_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_02_1 ">
+                    <iidm:property name="geographicalName" value="PT_02_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_02_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_02_1 " connectableBus="PT_02_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTCTGN" country="PT">
+        <iidm:voltageLevel id="PTCTGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTCTGN1 ">
+                    <iidm:property name="geographicalName" value="PTCTGN1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_03_1 ">
+                    <iidm:property name="geographicalName" value="PT_03_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTCTGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="PTCTGN1 " connectableBus="PTCTGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_03_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_03_1 " connectableBus="PT_03_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTCTGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTCTGN1 " connectableBus="PTCTGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_03_1  PTCTGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="PTCTGN1 " connectableBus1="PTCTGN1 " voltageLevelId1="PTCTGN1" bus2="PT_03_1 " connectableBus2="PT_03_1 " voltageLevelId2="PTCTGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PTCTGU" country="PT">
+        <iidm:voltageLevel id="PTCTGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTCTGU1 ">
+                    <iidm:property name="geographicalName" value="PTCTGU1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_04_1 ">
+                    <iidm:property name="geographicalName" value="PT_04_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTCTGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="PTCTGU1 " connectableBus="PTCTGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_04_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_04_1 " connectableBus="PT_04_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTCTGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTCTGU1 " connectableBus="PTCTGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_04_1  PTCTGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="PTCTGU1 " connectableBus1="PTCTGU1 " voltageLevelId1="PTCTGU1" bus2="PT_04_1 " connectableBus2="PT_04_1 " voltageLevelId2="PTCTGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PT_05_" country="PT">
+        <iidm:voltageLevel id="PT_05_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_05_1 ">
+                    <iidm:property name="geographicalName" value="PT_05_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_05_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_05_1 " connectableBus="PT_05_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PT_06_" country="PT">
+        <iidm:voltageLevel id="PT_06_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_06_1 ">
+                    <iidm:property name="geographicalName" value="PT_06_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_06_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_06_1 " connectableBus="PT_06_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTDTGN" country="PT">
+        <iidm:voltageLevel id="PTDTGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTDTGN1 ">
+                    <iidm:property name="geographicalName" value="PTDTGN1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_07_1 ">
+                    <iidm:property name="geographicalName" value="PT_07_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTDTGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTDTGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_07_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_07_1 " connectableBus="PT_07_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTDTGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTDTGN1 " connectableBus="PTDTGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_07_1  PTDTGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTDTGN1 " voltageLevelId1="PTDTGN1" connectableBus2="PT_07_1 " voltageLevelId2="PTDTGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PTDTGU" country="PT">
+        <iidm:voltageLevel id="PTDTGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTDTGU1 ">
+                    <iidm:property name="geographicalName" value="PTDTGU1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_08_1 ">
+                    <iidm:property name="geographicalName" value="PT_08_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTDTGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTDTGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_08_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_08_1 " connectableBus="PT_08_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTDTGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTDTGU1 " connectableBus="PTDTGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_08_1  PTDTGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTDTGU1 " voltageLevelId1="PTDTGU1" connectableBus2="PT_08_1 " voltageLevelId2="PTDTGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PTD2GN" country="PT">
+        <iidm:voltageLevel id="PTD2GN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTD2GN1 ">
+                    <iidm:property name="geographicalName" value="PTD2GN1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_09_1 ">
+                    <iidm:property name="geographicalName" value="PT_09_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTD2GN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTD2GN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_09_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_09_1 " connectableBus="PT_09_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTD2GN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTD2GN1 " connectableBus="PTD2GN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_09_1  PTD2GN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTD2GN1 " voltageLevelId1="PTD2GN1" connectableBus2="PT_09_1 " voltageLevelId2="PTD2GN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="PT_09_1  PTD2GN1  2" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTD2GN1 " voltageLevelId1="PTD2GN1" connectableBus2="PT_09_1 " voltageLevelId2="PTD2GN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PTD2GU" country="PT">
+        <iidm:voltageLevel id="PTD2GU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTD2GU1 ">
+                    <iidm:property name="geographicalName" value="PTD2GU1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_10_1 ">
+                    <iidm:property name="geographicalName" value="PT_10_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTD2GU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTD2GU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_10_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_10_1 " connectableBus="PT_10_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTD2GU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTD2GU1 " connectableBus="PTD2GU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_10_1  PTD2GU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTD2GU1 " voltageLevelId1="PTD2GU1" connectableBus2="PT_10_1 " voltageLevelId2="PTD2GU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="PT_10_1  PTD2GU1  2" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTD2GU1 " voltageLevelId1="PTD2GU1" connectableBus2="PT_10_1 " voltageLevelId2="PTD2GU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PT_11_" country="PT">
+        <iidm:voltageLevel id="PT_11_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_11_1 ">
+                    <iidm:property name="geographicalName" value="PT_11_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_11_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_11_1 " connectableBus="PT_11_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTCDGN" country="PT">
+        <iidm:voltageLevel id="PTCDGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTCDGN1 ">
+                    <iidm:property name="geographicalName" value="PTCDGN1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_12_1 ">
+                    <iidm:property name="geographicalName" value="PT_12_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTCDGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTCDGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_12_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_12_1 " connectableBus="PT_12_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTCDGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTCDGN1 " connectableBus="PTCDGN1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_12_1  PTCDGN1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTCDGN1 " voltageLevelId1="PTCDGN1" connectableBus2="PT_12_1 " voltageLevelId2="PTCDGN1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PT_13_" country="PT">
+        <iidm:voltageLevel id="PT_13_1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PT_13_1 ">
+                    <iidm:property name="geographicalName" value="PT_13_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PT_13_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_13_1 " connectableBus="PT_13_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTCDGU" country="PT">
+        <iidm:voltageLevel id="PTCDGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTCDGU1 ">
+                    <iidm:property name="geographicalName" value="PTCDGU1"/>
+                </iidm:bus>
+                <iidm:bus id="PT_14_1 ">
+                    <iidm:property name="geographicalName" value="PT_14_1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTCDGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTCDGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="PT_14_1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" bus="PT_14_1 " connectableBus="PT_14_1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTCDGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTCDGU1 " connectableBus="PTCDGU1 "/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="PT_14_1  PTCDGU1  1" r="0.1" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" connectableBus1="PTCDGU1 " voltageLevelId1="PTCDGU1" connectableBus2="PT_14_1 " voltageLevelId2="PTCDGU1">
+            <iidm:property name="nomimalPower" value="999.0"/>
+            <iidm:currentLimits2 permanentLimit="999999.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="PTDCGU" country="PT">
+        <iidm:voltageLevel id="PTDCGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTDCGU1 ">
+                    <iidm:property name="geographicalName" value="PTDCGU1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTDCGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="PTDCGU1 " connectableBus="PTDCGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTDCGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTDCGU1 " connectableBus="PTDCGU1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTDCGN" country="PT">
+        <iidm:voltageLevel id="PTDCGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTDCGN1 ">
+                    <iidm:property name="geographicalName" value="PTDCGN1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTDCGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="380.0" targetQ="0.0" bus="PTDCGN1 " connectableBus="PTDCGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTDCGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTDCGN1 " connectableBus="PTDCGN1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTDDGU" country="PT">
+        <iidm:voltageLevel id="PTDDGU1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTDDGU1 ">
+                    <iidm:property name="geographicalName" value="PTDDGU1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTDDGU1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTDDGU1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTDDGU1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTDDGU1 " connectableBus="PTDDGU1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="PTDDGN" country="PT">
+        <iidm:voltageLevel id="PTDDGN1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="PTDDGN1 ">
+                    <iidm:property name="geographicalName" value="PTDDGN1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="PTDDGN1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="380.0" targetQ="0.0" connectableBus="PTDDGN1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="PTDDGN1 _load" loadType="UNDEFINED" p0="0.0" q0="-2.0" bus="PTDDGN1 " connectableBus="PTDDGN1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="ES_01_1  ES_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_01_1 " connectableBus1="ES_01_1 " voltageLevelId1="ES_01_1" bus2="ES_04_1 " connectableBus2="ES_04_1 " voltageLevelId2="ESCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_10_1  ES_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_10_1 " connectableBus1="ES_10_1 " voltageLevelId1="ESD2GU1" bus2="ES_04_1 " connectableBus2="ES_04_1 " voltageLevelId2="ESCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_10_1  ES_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_10_1 " connectableBus1="ES_10_1 " voltageLevelId1="ESD2GU1" bus2="ES_08_1 " connectableBus2="ES_08_1 " voltageLevelId2="ESDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_11_1  ES_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_11_1 " connectableBus1="ES_11_1 " voltageLevelId1="ES_11_1" bus2="ES_08_1 " connectableBus2="ES_08_1 " voltageLevelId2="ESDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_11_1  ES_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_11_1 " connectableBus1="ES_11_1 " voltageLevelId1="ES_11_1" bus2="ES_05_1 " connectableBus2="ES_05_1 " voltageLevelId2="ES_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_02_1  ES_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_02_1 " connectableBus1="ES_02_1 " voltageLevelId1="ES_02_1" bus2="ES_05_1 " connectableBus2="ES_05_1 " voltageLevelId2="ES_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_02_1  ES_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_02_1 " connectableBus1="ES_02_1 " voltageLevelId1="ES_02_1" bus2="ES_03_1 " connectableBus2="ES_03_1 " voltageLevelId2="ESCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_07_1  ES_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_07_1 " connectableBus1="ES_07_1 " voltageLevelId1="ESDTGN1" bus2="ES_03_1 " connectableBus2="ES_03_1 " voltageLevelId2="ESCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_07_1  ES_13_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_07_1 " connectableBus1="ES_07_1 " voltageLevelId1="ESDTGN1" bus2="ES_13_1 " connectableBus2="ES_13_1 " voltageLevelId2="ES_13_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_09_1  ES_13_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_09_1 " connectableBus1="ES_09_1 " voltageLevelId1="ESD2GN1" bus2="ES_13_1 " connectableBus2="ES_13_1 " voltageLevelId2="ES_13_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_09_1  ES_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_09_1 " connectableBus1="ES_09_1 " voltageLevelId1="ESD2GN1" bus2="ES_06_1 " connectableBus2="ES_06_1 " voltageLevelId2="ES_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_01_1  ES_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_01_1 " connectableBus1="ES_01_1 " voltageLevelId1="ES_01_1" bus2="ES_06_1 " connectableBus2="ES_06_1 " voltageLevelId2="ES_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_11_1  ES_12_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" connectableBus1="ES_11_1 " voltageLevelId1="ES_11_1" connectableBus2="ES_12_1 " voltageLevelId2="ESCDGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_13_1  ES_14_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" connectableBus1="ES_13_1 " voltageLevelId1="ES_13_1" connectableBus2="ES_14_1 " voltageLevelId2="ESCDGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L1_1  ES_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L1_1 " connectableBus1="ES_L1_1 " voltageLevelId1="ES_L1_1" bus2="ES_E1_1 " connectableBus2="ES_E1_1 " voltageLevelId2="ES_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L2_1  ES_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L2_1 " connectableBus1="ES_L2_1 " voltageLevelId1="ES_L2_1" bus2="ES_E1_1 " connectableBus2="ES_E1_1 " voltageLevelId2="ES_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L1_1  ES_02_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L1_1 " connectableBus1="ES_L1_1 " voltageLevelId1="ES_L1_1" bus2="ES_02_1 " connectableBus2="ES_02_1 " voltageLevelId2="ES_02_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L1_1  ES_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L1_1 " connectableBus1="ES_L1_1 " voltageLevelId1="ES_L1_1" bus2="ES_04_1 " connectableBus2="ES_04_1 " voltageLevelId2="ESCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L1_1  ES_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L1_1 " connectableBus1="ES_L1_1 " voltageLevelId1="ES_L1_1" bus2="ES_05_1 " connectableBus2="ES_05_1 " voltageLevelId2="ES_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L1_1  ES_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L1_1 " connectableBus1="ES_L1_1 " voltageLevelId1="ES_L1_1" bus2="ES_08_1 " connectableBus2="ES_08_1 " voltageLevelId2="ESDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L1_1  ES_10_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L1_1 " connectableBus1="ES_L1_1 " voltageLevelId1="ES_L1_1" bus2="ES_10_1 " connectableBus2="ES_10_1 " voltageLevelId2="ESD2GU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L2_1  ES_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L2_1 " connectableBus1="ES_L2_1 " voltageLevelId1="ES_L2_1" bus2="ES_03_1 " connectableBus2="ES_03_1 " voltageLevelId2="ESCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L2_1  ES_01_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L2_1 " connectableBus1="ES_L2_1 " voltageLevelId1="ES_L2_1" bus2="ES_01_1 " connectableBus2="ES_01_1 " voltageLevelId2="ES_01_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L2_1  ES_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L2_1 " connectableBus1="ES_L2_1 " voltageLevelId1="ES_L2_1" bus2="ES_06_1 " connectableBus2="ES_06_1 " voltageLevelId2="ES_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L2_1  ES_07_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L2_1 " connectableBus1="ES_L2_1 " voltageLevelId1="ES_L2_1" bus2="ES_07_1 " connectableBus2="ES_07_1 " voltageLevelId2="ESDTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_L2_1  ES_09_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_L2_1 " connectableBus1="ES_L2_1 " voltageLevelId1="ES_L2_1" bus2="ES_09_1 " connectableBus2="ES_09_1 " voltageLevelId2="ESD2GN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_01_1  ESDCGN1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_01_1 " connectableBus1="ES_01_1 " voltageLevelId1="ES_01_1" bus2="ESDCGN1 " connectableBus2="ESDCGN1 " voltageLevelId2="ESDCGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_02_1  ESDCGU1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_02_1 " connectableBus1="ES_02_1 " voltageLevelId1="ES_02_1" bus2="ESDCGU1 " connectableBus2="ESDCGU1 " voltageLevelId2="ESDCGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_05_1  ESDDGN1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_05_1 " connectableBus1="ES_05_1 " voltageLevelId1="ES_05_1" bus2="ESDDGN1 " connectableBus2="ESDDGN1 " voltageLevelId2="ESDDGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_06_1  ESDDGU1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_06_1 " connectableBus1="ES_06_1 " voltageLevelId1="ES_06_1" bus2="ESDDGU1 " connectableBus2="ESDDGU1 " voltageLevelId2="ESDDGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_01_1  FR_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_01_1 " connectableBus1="FR_01_1 " voltageLevelId1="FR_01_1" bus2="FR_04_1 " connectableBus2="FR_04_1 " voltageLevelId2="FRCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_10_1  FR_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_10_1 " connectableBus1="FR_10_1 " voltageLevelId1="FRD2GU1" bus2="FR_04_1 " connectableBus2="FR_04_1 " voltageLevelId2="FRCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_10_1  FR_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_10_1 " connectableBus1="FR_10_1 " voltageLevelId1="FRD2GU1" bus2="FR_08_1 " connectableBus2="FR_08_1 " voltageLevelId2="FRDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_11_1  FR_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_11_1 " connectableBus1="FR_11_1 " voltageLevelId1="FR_11_1" bus2="FR_08_1 " connectableBus2="FR_08_1 " voltageLevelId2="FRDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_11_1  FR_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_11_1 " connectableBus1="FR_11_1 " voltageLevelId1="FR_11_1" bus2="FR_05_1 " connectableBus2="FR_05_1 " voltageLevelId2="FR_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_02_1  FR_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_02_1 " connectableBus1="FR_02_1 " voltageLevelId1="FR_02_1" bus2="FR_05_1 " connectableBus2="FR_05_1 " voltageLevelId2="FR_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_02_1  FR_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_02_1 " connectableBus1="FR_02_1 " voltageLevelId1="FR_02_1" bus2="FR_03_1 " connectableBus2="FR_03_1 " voltageLevelId2="FRCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_07_1  FR_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_07_1 " connectableBus1="FR_07_1 " voltageLevelId1="FRDTGN1" bus2="FR_03_1 " connectableBus2="FR_03_1 " voltageLevelId2="FRCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_07_1  FR_13_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_07_1 " connectableBus1="FR_07_1 " voltageLevelId1="FRDTGN1" bus2="FR_13_1 " connectableBus2="FR_13_1 " voltageLevelId2="FR_13_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_09_1  FR_13_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_09_1 " connectableBus1="FR_09_1 " voltageLevelId1="FRD2GN1" bus2="FR_13_1 " connectableBus2="FR_13_1 " voltageLevelId2="FR_13_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_09_1  FR_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_09_1 " connectableBus1="FR_09_1 " voltageLevelId1="FRD2GN1" bus2="FR_06_1 " connectableBus2="FR_06_1 " voltageLevelId2="FR_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_01_1  FR_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_01_1 " connectableBus1="FR_01_1 " voltageLevelId1="FR_01_1" bus2="FR_06_1 " connectableBus2="FR_06_1 " voltageLevelId2="FR_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_11_1  FR_12_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" connectableBus1="FR_11_1 " voltageLevelId1="FR_11_1" connectableBus2="FR_12_1 " voltageLevelId2="FRCDGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_13_1  FR_14_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" connectableBus1="FR_13_1 " voltageLevelId1="FR_13_1" connectableBus2="FR_14_1 " voltageLevelId2="FRCDGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L1_1  FR_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L1_1 " connectableBus1="FR_L1_1 " voltageLevelId1="FR_L1_1" bus2="FR_E1_1 " connectableBus2="FR_E1_1 " voltageLevelId2="FR_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L2_1  FR_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L2_1 " connectableBus1="FR_L2_1 " voltageLevelId1="FR_L2_1" bus2="FR_E1_1 " connectableBus2="FR_E1_1 " voltageLevelId2="FR_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L1_1  FR_02_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L1_1 " connectableBus1="FR_L1_1 " voltageLevelId1="FR_L1_1" bus2="FR_02_1 " connectableBus2="FR_02_1 " voltageLevelId2="FR_02_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L1_1  FR_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L1_1 " connectableBus1="FR_L1_1 " voltageLevelId1="FR_L1_1" bus2="FR_04_1 " connectableBus2="FR_04_1 " voltageLevelId2="FRCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L1_1  FR_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L1_1 " connectableBus1="FR_L1_1 " voltageLevelId1="FR_L1_1" bus2="FR_05_1 " connectableBus2="FR_05_1 " voltageLevelId2="FR_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L1_1  FR_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L1_1 " connectableBus1="FR_L1_1 " voltageLevelId1="FR_L1_1" bus2="FR_08_1 " connectableBus2="FR_08_1 " voltageLevelId2="FRDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L1_1  FR_10_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L1_1 " connectableBus1="FR_L1_1 " voltageLevelId1="FR_L1_1" bus2="FR_10_1 " connectableBus2="FR_10_1 " voltageLevelId2="FRD2GU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L2_1  FR_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L2_1 " connectableBus1="FR_L2_1 " voltageLevelId1="FR_L2_1" bus2="FR_03_1 " connectableBus2="FR_03_1 " voltageLevelId2="FRCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L2_1  FR_01_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L2_1 " connectableBus1="FR_L2_1 " voltageLevelId1="FR_L2_1" bus2="FR_01_1 " connectableBus2="FR_01_1 " voltageLevelId2="FR_01_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L2_1  FR_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L2_1 " connectableBus1="FR_L2_1 " voltageLevelId1="FR_L2_1" bus2="FR_06_1 " connectableBus2="FR_06_1 " voltageLevelId2="FR_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L2_1  FR_07_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L2_1 " connectableBus1="FR_L2_1 " voltageLevelId1="FR_L2_1" bus2="FR_07_1 " connectableBus2="FR_07_1 " voltageLevelId2="FRDTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_L2_1  FR_09_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_L2_1 " connectableBus1="FR_L2_1 " voltageLevelId1="FR_L2_1" bus2="FR_09_1 " connectableBus2="FR_09_1 " voltageLevelId2="FRD2GN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_01_1  FRDCGN1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_01_1 " connectableBus1="FR_01_1 " voltageLevelId1="FR_01_1" bus2="FRDCGN1 " connectableBus2="FRDCGN1 " voltageLevelId2="FRDCGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_02_1  FRDCGU1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_02_1 " connectableBus1="FR_02_1 " voltageLevelId1="FR_02_1" bus2="FRDCGU1 " connectableBus2="FRDCGU1 " voltageLevelId2="FRDCGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_05_1  FRDDGN1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_05_1 " connectableBus1="FR_05_1 " voltageLevelId1="FR_05_1" bus2="FRDDGN1 " connectableBus2="FRDDGN1 " voltageLevelId2="FRDDGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FR_06_1  FRDDGU1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="FR_06_1 " connectableBus1="FR_06_1 " voltageLevelId1="FR_06_1" bus2="FRDDGU1 " connectableBus2="FRDDGU1 " voltageLevelId2="FRDDGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_01_1  PT_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_01_1 " connectableBus1="PT_01_1 " voltageLevelId1="PT_01_1" bus2="PT_04_1 " connectableBus2="PT_04_1 " voltageLevelId2="PTCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_10_1  PT_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_10_1 " connectableBus1="PT_10_1 " voltageLevelId1="PTD2GU1" bus2="PT_04_1 " connectableBus2="PT_04_1 " voltageLevelId2="PTCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_10_1  PT_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_10_1 " connectableBus1="PT_10_1 " voltageLevelId1="PTD2GU1" bus2="PT_08_1 " connectableBus2="PT_08_1 " voltageLevelId2="PTDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_11_1  PT_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_11_1 " connectableBus1="PT_11_1 " voltageLevelId1="PT_11_1" bus2="PT_08_1 " connectableBus2="PT_08_1 " voltageLevelId2="PTDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_11_1  PT_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_11_1 " connectableBus1="PT_11_1 " voltageLevelId1="PT_11_1" bus2="PT_05_1 " connectableBus2="PT_05_1 " voltageLevelId2="PT_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_02_1  PT_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_02_1 " connectableBus1="PT_02_1 " voltageLevelId1="PT_02_1" bus2="PT_05_1 " connectableBus2="PT_05_1 " voltageLevelId2="PT_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_02_1  PT_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_02_1 " connectableBus1="PT_02_1 " voltageLevelId1="PT_02_1" bus2="PT_03_1 " connectableBus2="PT_03_1 " voltageLevelId2="PTCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_07_1  PT_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_07_1 " connectableBus1="PT_07_1 " voltageLevelId1="PTDTGN1" bus2="PT_03_1 " connectableBus2="PT_03_1 " voltageLevelId2="PTCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_07_1  PT_13_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_07_1 " connectableBus1="PT_07_1 " voltageLevelId1="PTDTGN1" bus2="PT_13_1 " connectableBus2="PT_13_1 " voltageLevelId2="PT_13_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_09_1  PT_13_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_09_1 " connectableBus1="PT_09_1 " voltageLevelId1="PTD2GN1" bus2="PT_13_1 " connectableBus2="PT_13_1 " voltageLevelId2="PT_13_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_09_1  PT_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_09_1 " connectableBus1="PT_09_1 " voltageLevelId1="PTD2GN1" bus2="PT_06_1 " connectableBus2="PT_06_1 " voltageLevelId2="PT_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_01_1  PT_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_01_1 " connectableBus1="PT_01_1 " voltageLevelId1="PT_01_1" bus2="PT_06_1 " connectableBus2="PT_06_1 " voltageLevelId2="PT_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_11_1  PT_12_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" connectableBus1="PT_11_1 " voltageLevelId1="PT_11_1" connectableBus2="PT_12_1 " voltageLevelId2="PTCDGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_13_1  PT_14_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" connectableBus1="PT_13_1 " voltageLevelId1="PT_13_1" connectableBus2="PT_14_1 " voltageLevelId2="PTCDGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L1_1  PT_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L1_1 " connectableBus1="PT_L1_1 " voltageLevelId1="PT_L1_1" bus2="PT_E1_1 " connectableBus2="PT_E1_1 " voltageLevelId2="PT_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L2_1  PT_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L2_1 " connectableBus1="PT_L2_1 " voltageLevelId1="PT_L2_1" bus2="PT_E1_1 " connectableBus2="PT_E1_1 " voltageLevelId2="PT_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L1_1  PT_02_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L1_1 " connectableBus1="PT_L1_1 " voltageLevelId1="PT_L1_1" bus2="PT_02_1 " connectableBus2="PT_02_1 " voltageLevelId2="PT_02_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L1_1  PT_04_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L1_1 " connectableBus1="PT_L1_1 " voltageLevelId1="PT_L1_1" bus2="PT_04_1 " connectableBus2="PT_04_1 " voltageLevelId2="PTCTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L1_1  PT_05_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L1_1 " connectableBus1="PT_L1_1 " voltageLevelId1="PT_L1_1" bus2="PT_05_1 " connectableBus2="PT_05_1 " voltageLevelId2="PT_05_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L1_1  PT_08_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L1_1 " connectableBus1="PT_L1_1 " voltageLevelId1="PT_L1_1" bus2="PT_08_1 " connectableBus2="PT_08_1 " voltageLevelId2="PTDTGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L1_1  PT_10_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L1_1 " connectableBus1="PT_L1_1 " voltageLevelId1="PT_L1_1" bus2="PT_10_1 " connectableBus2="PT_10_1 " voltageLevelId2="PTD2GU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L2_1  PT_03_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L2_1 " connectableBus1="PT_L2_1 " voltageLevelId1="PT_L2_1" bus2="PT_03_1 " connectableBus2="PT_03_1 " voltageLevelId2="PTCTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L2_1  PT_01_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L2_1 " connectableBus1="PT_L2_1 " voltageLevelId1="PT_L2_1" bus2="PT_01_1 " connectableBus2="PT_01_1 " voltageLevelId2="PT_01_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L2_1  PT_06_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L2_1 " connectableBus1="PT_L2_1 " voltageLevelId1="PT_L2_1" bus2="PT_06_1 " connectableBus2="PT_06_1 " voltageLevelId2="PT_06_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L2_1  PT_07_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L2_1 " connectableBus1="PT_L2_1 " voltageLevelId1="PT_L2_1" bus2="PT_07_1 " connectableBus2="PT_07_1 " voltageLevelId2="PTDTGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_L2_1  PT_09_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_L2_1 " connectableBus1="PT_L2_1 " voltageLevelId1="PT_L2_1" bus2="PT_09_1 " connectableBus2="PT_09_1 " voltageLevelId2="PTD2GN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_01_1  PTDCGN1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_01_1 " connectableBus1="PT_01_1 " voltageLevelId1="PT_01_1" bus2="PTDCGN1 " connectableBus2="PTDCGN1 " voltageLevelId2="PTDCGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_02_1  PTDCGU1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_02_1 " connectableBus1="PT_02_1 " voltageLevelId1="PT_02_1" bus2="PTDCGU1 " connectableBus2="PTDCGU1 " voltageLevelId2="PTDCGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_05_1  PTDDGN1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_05_1 " connectableBus1="PT_05_1 " voltageLevelId1="PT_05_1" bus2="PTDDGN1 " connectableBus2="PTDDGN1 " voltageLevelId2="PTDDGN1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_06_1  PTDDGU1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_06_1 " connectableBus1="PT_06_1 " voltageLevelId1="PT_06_1" bus2="PTDDGU1 " connectableBus2="PTDDGU1 " voltageLevelId2="PTDDGU1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="PT_E1_1  ES_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="PT_E1_1 " connectableBus1="PT_E1_1 " voltageLevelId1="PT_E1_1" bus2="ES_E1_1 " connectableBus2="ES_E1_1 " voltageLevelId2="ES_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ES_E1_1  FR_E1_1  1" r="2.0" x="10.0" g1="0.0" b1="2.4999999999999998E-5" g2="0.0" b2="2.4999999999999998E-5" bus1="ES_E1_1 " connectableBus1="ES_E1_1 " voltageLevelId1="ES_E1_1" bus2="FR_E1_1 " connectableBus2="FR_E1_1 " voltageLevelId2="FR_E1_1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+</iidm:network>

--- a/gridcapa-swe-runner-app/src/test/resources/shift/TestCase_with_transformers_glsk.xml
+++ b/gridcapa-swe-runner-app/src/test/resources/shift/TestCase_with_transformers_glsk.xml
@@ -1,0 +1,693 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GLSK_MarketDocument xmlns="urn:iec62325.351:tc57wg16:451-n:glskdocument:2:1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iec62325.351:tc57wg16:451-n:glskdocument:2:1 iec62325-451-n-glsk_v2_1.xsd">
+  <mRID>CORESO-20230731-SWECCD2-F008</mRID>
+  <revisionNumber>1</revisionNumber>
+  <type>B22</type>
+  <process.processType>A48</process.processType>
+  <sender_MarketParticipant.mRID codingScheme="A01">22XCORESO------S</sender_MarketParticipant.mRID>
+  <sender_MarketParticipant.marketRole.type>A36</sender_MarketParticipant.marketRole.type>
+  <receiver_MarketParticipant.mRID codingScheme="A01">10XPT-REN------9</receiver_MarketParticipant.mRID>
+  <receiver_MarketParticipant.marketRole.type>A04</receiver_MarketParticipant.marketRole.type>
+  <createdDateTime>2023-07-29T15:05:00Z</createdDateTime>
+  <status>
+    <value>A42</value>
+  </status>
+  <time_Period.timeInterval>
+    <start>2023-07-30T22:00Z</start>
+    <end>2023-07-31T22:00Z</end>
+  </time_Period.timeInterval>
+  <domain.mRID codingScheme="A01">10YCB-FR-ES-PT-S</domain.mRID>
+  <TimeSeries>
+    <mRID>ES-TimeSeries</mRID>
+    <subject_Domain.mRID codingScheme="A01">10YES-REE------0</subject_Domain.mRID>
+    <curveType>A01</curveType>
+    <Period>
+      <timeInterval>
+        <start>2023-07-30T22:00Z</start>
+        <end>2023-07-31T22:00Z</end>
+      </timeInterval>
+      <resolution>PT60M</resolution>
+      <Point>
+        <position>10</position>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCDGU1 _generator</mRID>
+            <name>ES completely disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESD2GU1 _generator</mRID>
+            <name>ES disconnected generator through 2 transformers - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDCGU1 _generator</mRID>
+            <name>ES directly connected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCTGU1 _generator</mRID>
+            <name>ES connected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDDGU1 _generator</mRID>
+            <name>ES directly disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDTGU1 _generator</mRID>
+            <name>ES disconnected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>250.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCDGN1 _generator</mRID>
+            <name>ES completely disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESD2GN1 _generator</mRID>
+            <name>ES disconnected generator through 2 transformers - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDCGN1 _generator</mRID>
+            <name>ES directly connected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCTGN1 _generator</mRID>
+            <name>ES connected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDDGN1 _generator</mRID>
+            <name>ES directly disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDTGN1 _generator</mRID>
+            <name>ES disconnected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCDGU1 _generator</mRID>
+            <name>ES completely disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESD2GU1 _generator</mRID>
+            <name>ES disconnected generator through 2 transformers - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDCGU1 _generator</mRID>
+            <name>ES directly connected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCTGU1 _generator</mRID>
+            <name>ES connected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDDGU1 _generator</mRID>
+            <name>ES directly disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDTGU1 _generator</mRID>
+            <name>ES disconnected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCDGN1 _generator</mRID>
+            <name>ES completely disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESD2GN1 _generator</mRID>
+            <name>ES disconnected generator through 2 transformers - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDCGN1 _generator</mRID>
+            <name>ES directly connected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESCTGN1 _generator</mRID>
+            <name>ES connected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDDGN1 _generator</mRID>
+            <name>ES directly disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">ESDTGN1 _generator</mRID>
+            <name>ES disconnected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+      </Point>
+    </Period>
+  </TimeSeries>
+  <TimeSeries>
+    <mRID>PT-TimeSeries</mRID>
+    <subject_Domain.mRID codingScheme="A01">10YPT-REN------W</subject_Domain.mRID>
+    <curveType>A01</curveType>
+    <Period>
+      <timeInterval>
+        <start>2023-07-30T22:00Z</start>
+        <end>2023-07-31T22:00Z</end>
+      </timeInterval>
+      <resolution>PT60M</resolution>
+      <Point>
+        <position>10</position>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCDGU1 _generator</mRID>
+            <name>PT completely disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTD2GU1 _generator</mRID>
+            <name>PT disconnected generator through 2 transformers - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDCGU1 _generator</mRID>
+            <name>PT directly connected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCTGU1 _generator</mRID>
+            <name>PT connected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDDGU1 _generator</mRID>
+            <name>PT directly disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDTGU1 _generator</mRID>
+            <name>PT disconnected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>250.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCDGN1 _generator</mRID>
+            <name>PT completely disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTD2GN1 _generator</mRID>
+            <name>PT disconnected generator through 2 transformers - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDCGN1 _generator</mRID>
+            <name>PT directly connected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCTGN1 _generator</mRID>
+            <name>PT connected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDDGN1 _generator</mRID>
+            <name>PT directly disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDTGN1 _generator</mRID>
+            <name>PT disconnected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries><SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCDGU1 _generator</mRID>
+            <name>PT completely disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTD2GU1 _generator</mRID>
+            <name>PT disconnected generator through 2 transformers - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDCGU1 _generator</mRID>
+            <name>PT directly connected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCTGU1 _generator</mRID>
+            <name>PT connected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDDGU1 _generator</mRID>
+            <name>PT directly disconnected generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDTGU1 _generator</mRID>
+            <name>PT disconnected through transformer generator - will be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCDGN1 _generator</mRID>
+            <name>PT completely disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A02</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTD2GN1 _generator</mRID>
+            <name>PT disconnected generator through 2 transformers - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDCGN1 _generator</mRID>
+            <name>PT directly connected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTCTGN1 _generator</mRID>
+            <name>PT connected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>1200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDDGN1 _generator</mRID>
+            <name>PT directly disconnected generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B45</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <flowDirection.direction>A01</flowDirection.direction>
+          <measurement_Unit.name>MAW</measurement_Unit.name>
+          <attributeInstanceComponent.position>1</attributeInstanceComponent.position>
+          <RegisteredResource>
+            <mRID codingScheme="A02">PTDTGN1 _generator</mRID>
+            <name>PT disconnected through transformer generator - will not be used in scaling</name>
+            <resourceCapacity.maximumCapacity>200.00</resourceCapacity.maximumCapacity>
+            <resourceCapacity.minimumCapacity>0.0</resourceCapacity.minimumCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+      </Point>
+    </Period>
+  </TimeSeries>
+  <TimeSeries>
+    <mRID>FR-TimeSeries</mRID>
+    <subject_Domain.mRID codingScheme="A01">10YFR-RTE------C</subject_Domain.mRID>
+    <curveType>A03</curveType>
+    <Period>
+      <timeInterval>
+        <start>2018-03-27T22:00Z</start>
+        <end>2018-03-28T22:00Z</end>
+      </timeInterval>
+      <resolution>PT60M</resolution>
+      <Point>
+        <position>1</position>
+        <SKBlock_TimeSeries>
+          <businessType>B42</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <measurement_Unit.name>C62</measurement_Unit.name>
+        </SKBlock_TimeSeries>
+      </Point>
+    </Period>
+  </TimeSeries>
+</GLSK_MarketDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
When a ES or PT scalable is connected to grid through a disconnected transformer, it cannot be scaled.


**What is the new behavior (if this is a feature change)?**
Before scaling, transformers are connected. After scaling, transformers of generators that were not scaled are re-disconnected.
