### PR TITLE
avoid null pointer exception when raoResult is null

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyLogging.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyLogging.java
@@ -82,7 +82,7 @@ public class DichotomyLogging {
         String angleCheckStatus = NONE;
         final String limitingCause = dichotomyResult.getLimitingCause() != null ? DichotomyResultHelper.limitingCauseToString(dichotomyResult.getLimitingCause()) : NONE;
         final Crac crac = (direction == DichotomyDirection.ES_FR || direction == DichotomyDirection.FR_ES) ? sweData.getCracFrEs().getCrac() : sweData.getCracEsPt().getCrac();
-        if (dichotomyResult.getLowestInvalidStep() != null) {
+        if (dichotomyResult.getLowestInvalidStep() != null && dichotomyResult.getLowestInvalidStep().getRaoResult() != null) {
             final RaoResult raoResult = dichotomyResult.getLowestInvalidStep().getRaoResult();
             limitingElement = DichotomyResultHelper.getLimitingElement(crac, raoResult);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the logging process by enhancing null-checking logic for the `lowestInvalidStep` property.
	- Ensured robustness by verifying associated `RaoResult` is not null before accessing properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->