### PR TITLE
Revert "Update of Reason and Error code in the CNE first_unsecure wit…

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CneFileExportService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CneFileExportService.java
@@ -108,7 +108,7 @@ public class CneFileExportService {
         return sweData.getCracFrEs();
     }
 
-    void exportAndZipCneFile(SweData sweData,
+    private void exportAndZipCneFile(SweData sweData,
                                      DichotomyDirection direction,
                                      DichotomyResult<SweDichotomyValidationData> dichotomyResult,
                                      Properties cneExporterProperties,
@@ -122,10 +122,6 @@ public class CneFileExportService {
             final RaoResult raoResult = extractRaoResult(dichotomyResult, isHighestValid);
             if (raoResult == null) {
                 final Reason reason = getLimitingCauseErrorReason(dichotomyResult.getLimitingCause());
-                final CriticalNetworkElementMarketDocument errorMarketDocument = createErrorMarketDocument(sweData, direction, cneExporterProperties, cracCreationContext, reason);
-                marshallMarketDocumentToXml(zipOs, errorMarketDocument);
-            } else if (raoResult.getExecutionDetails() != null && !isHighestValid) {
-                final Reason reason = getReason("B18", raoResult.getExecutionDetails());
                 final CriticalNetworkElementMarketDocument errorMarketDocument = createErrorMarketDocument(sweData, direction, cneExporterProperties, cracCreationContext, reason);
                 marshallMarketDocumentToXml(zipOs, errorMarketDocument);
             } else {
@@ -205,7 +201,7 @@ public class CneFileExportService {
         }
     }
 
-    Properties getCneExporterProperties(OffsetDateTime timestamp) {
+    private Properties getCneExporterProperties(OffsetDateTime timestamp) {
         // limit size to 35 characters, a UUID is 36 characters long
         final String mRid = UUID.randomUUID().toString().substring(1);
         final Properties properties = new Properties();

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/CriticalNetworkElementMarketDocumentXmlRoot.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/CriticalNetworkElementMarketDocumentXmlRoot.java
@@ -1,8 +1,0 @@
-package com.farao_community.farao.swe.runner.app;
-
-import com.powsybl.openrao.data.raoresult.io.cne.swe.xsd.CriticalNetworkElementMarketDocument;
-import jakarta.xml.bind.annotation.XmlRootElement;
-
-@XmlRootElement(name = "CriticalNetworkElement_MarketDocument", namespace = "urn:iec62325.351:tc57wg16:451-n:cnedocument:2:3")
-public class CriticalNetworkElementMarketDocumentXmlRoot extends CriticalNetworkElementMarketDocument  {
-}


### PR DESCRIPTION
…h RaoResult's executionDetails (#312)"

This reverts commit ade70ec8

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated method visibility for `exportAndZipCneFile` and `getCneExporterProperties` methods in `CneFileExportService`
	- Removed `CriticalNetworkElementMarketDocumentXmlRoot` test class
	- Deleted a test method in `CneFileExportServiceTest`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->