### PR TITLE
Generate CNE First unsecure for failed RAO with error code B18

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweDichotomyResult.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweDichotomyResult.java
@@ -43,8 +43,9 @@ public class SweDichotomyResult {
     }
 
     public SweDichotomyResult(DichotomyDirection dichotomyDirection,
-                              DichotomyResult<SweDichotomyValidationData> dichotomyResult) {
-        this(dichotomyDirection, dichotomyResult, Optional.empty(), null, null, null);
+                              DichotomyResult<SweDichotomyValidationData> dichotomyResult,
+                              String lowestInvalidStepUrl) {
+        this(dichotomyDirection, dichotomyResult, Optional.empty(), null, null, lowestInvalidStepUrl);
     }
 
     public DichotomyDirection getDichotomyDirection() {

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/parallelization/DichotomyParallelizationWorker.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/parallelization/DichotomyParallelizationWorker.java
@@ -67,7 +67,8 @@ public class DichotomyParallelizationWorker {
         dichotomyLogging.logEndOneDichotomy();
 
         if (dichotomyResult.isRaoFailed()) {
-            return new AsyncResult<>(new SweDichotomyResult(direction, dichotomyResult));
+            final String lowestInvalidStepUrl = cneFileExportService.exportCneUrl(sweData, dichotomyResult, false, direction);
+            return new AsyncResult<>(new SweDichotomyResult(direction, dichotomyResult, lowestInvalidStepUrl));
         }
 
         // Generate files specific for one direction (cne, cgm, voltage) and add them to the returned object (to create)

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CneFileExportService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CneFileExportService.java
@@ -132,7 +132,7 @@ public class CneFileExportService {
     }
 
     private void handleFirstUnsecureForFailedRao(final SweData sweData, final DichotomyDirection direction, final Properties cneExporterProperties, final CimCracCreationContext cracCreationContext, final ZipOutputStream zipOs) throws DatatypeConfigurationException, JAXBException, IOException {
-        final Reason reason = getReason("B18", "RAO failed");
+        final Reason reason = getReason("B18", "RAO failure");
         fillCneWithError(sweData, direction, cneExporterProperties, cracCreationContext, zipOs, reason);
     }
 

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CneFileExportService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CneFileExportService.java
@@ -120,6 +120,7 @@ public class CneFileExportService {
             ZipOutputStream zipOs = new ZipOutputStream(os)) {
             zipOs.putNextEntry(new ZipEntry(fileExporter.zipTargetNameChangeExtension(targetZipFileName, ".xml")));
             if (!isHighestValid && dichotomyResult.isRaoFailed()) {
+                // The RAO failed and we want to generate a CNE First unsecure: generate the CNE file with B18 failure message
                 handleFirstUnsecureForFailedRao(sweData, direction, cneExporterProperties, cracCreationContext, zipOs);
             } else {
                 handleOtherResult(sweData, direction, dichotomyResult, cneExporterProperties, cracCreationContext, isHighestValid, zipOs);
@@ -138,9 +139,11 @@ public class CneFileExportService {
     private void handleOtherResult(final SweData sweData, final DichotomyDirection direction, final DichotomyResult<SweDichotomyValidationData> dichotomyResult, final Properties cneExporterProperties, final CimCracCreationContext cracCreationContext, final boolean isHighestValid, final ZipOutputStream zipOs) throws DatatypeConfigurationException, JAXBException, IOException {
         final RaoResult raoResult = extractRaoResult(dichotomyResult, isHighestValid);
         if (raoResult == null) {
+            // No RaoResult available for highest valid / lowest invalid step: generate a CNE file with limiting cause
             final Reason reason = getLimitingCauseErrorReason(dichotomyResult.getLimitingCause());
             fillCneWithError(sweData, direction, cneExporterProperties, cracCreationContext, zipOs, reason);
         } else {
+            // There is a RaoResult for highest valid / lowest invalid step, its data can be exported in CNE file
             raoResult.write("SWE-CNE", cracCreationContext, cneExporterProperties, zipOs);
         }
     }

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelizationTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelizationTest.java
@@ -356,7 +356,7 @@ class DichotomyParallelizationTest {
     @Test
     void testParallelizationWithOneRaoFailure() {
         DichotomyResult<SweDichotomyValidationData> failedSweDichotomyResult = DichotomyResult.buildFromRaoFailure("My test failure");
-        SweDichotomyResult failedResult = new SweDichotomyResult(DichotomyDirection.ES_PT, failedSweDichotomyResult);
+        SweDichotomyResult failedResult = new SweDichotomyResult(DichotomyDirection.ES_PT, failedSweDichotomyResult, "cneFirstUnsecureUrl");
 
         when(dichotomyRunner.run(any(SweData.class), any(SweTaskParameters.class), any(DichotomyDirection.class))).thenReturn(sweDichotomyResult);
         when(outputService.buildAndExportTtcDocument(any(SweData.class), any(ExecutionResult.class))).thenReturn("ttcDocUrl");
@@ -387,7 +387,7 @@ class DichotomyParallelizationTest {
     @Test
     void testParallelizationWithTwoDirectionsAllRaoFailure() {
         DichotomyResult<SweDichotomyValidationData> failedSweDichotomyResult = DichotomyResult.buildFromRaoFailure("My test failure");
-        SweDichotomyResult failedResult = new SweDichotomyResult(DichotomyDirection.ES_PT, failedSweDichotomyResult);
+        SweDichotomyResult failedResult = new SweDichotomyResult(DichotomyDirection.ES_PT, failedSweDichotomyResult, "cneFirstUnsecureUrl");
 
         when(dichotomyRunner.run(any(SweData.class), any(SweTaskParameters.class), any(DichotomyDirection.class))).thenReturn(sweDichotomyResult);
         when(outputService.buildAndExportTtcDocument(any(SweData.class), any(ExecutionResult.class))).thenReturn("ttcDocUrl");
@@ -418,7 +418,7 @@ class DichotomyParallelizationTest {
     @Test
     void testParallelizationWithFourDirectionsAllRaoFailure() {
         DichotomyResult<SweDichotomyValidationData> failedSweDichotomyResult = DichotomyResult.buildFromRaoFailure("My test failure");
-        SweDichotomyResult failedResult = new SweDichotomyResult(DichotomyDirection.ES_PT, failedSweDichotomyResult);
+        SweDichotomyResult failedResult = new SweDichotomyResult(DichotomyDirection.ES_PT, failedSweDichotomyResult, "cneFirstUnsecureUrl");
 
         when(dichotomyRunner.run(any(SweData.class), any(SweTaskParameters.class), any(DichotomyDirection.class))).thenReturn(sweDichotomyResult);
         when(outputService.buildAndExportTtcDocument(any(SweData.class), any(ExecutionResult.class))).thenReturn("ttcDocUrl");

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweDichotomyResultTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweDichotomyResultTest.java
@@ -82,13 +82,13 @@ class SweDichotomyResultTest {
     @Test
     void simpleTestWithRaoFailure() {
         DichotomyResult<SweDichotomyValidationData> customDichotomyResult = DichotomyResult.buildFromRaoFailure("failure");
-        SweDichotomyResult result = new SweDichotomyResult(DichotomyDirection.ES_FR, customDichotomyResult);
+        SweDichotomyResult result = new SweDichotomyResult(DichotomyDirection.ES_FR, customDichotomyResult, "cneFirstUnsecureUrl");
         assertEquals(DichotomyDirection.ES_FR, result.getDichotomyDirection());
         assertEquals(customDichotomyResult, result.getDichotomyResult());
         assertFalse(result.isInterrupted());
         assertFalse(result.getVoltageMonitoringResult().isPresent());
         assertNull(result.getHighestValidStepUrl());
-        assertNull(result.getLowestInvalidStepUrl());
+        assertEquals("cneFirstUnsecureUrl", result.getLowestInvalidStepUrl());
         assertNull(result.getExportedCgmesUrl());
         assertEquals(customDichotomyResult, result.getDichotomyResult());
         assertTrue(result.isRaoFailed());

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/CneFileExportServiceTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/CneFileExportServiceTest.java
@@ -317,6 +317,6 @@ class CneFileExportServiceTest {
                 .first()
                 .isInstanceOf(Reason.class)
                 .hasFieldOrPropertyWithValue("code", "B18")
-                .hasFieldOrPropertyWithValue("text", "RAO failed");
+                .hasFieldOrPropertyWithValue("text", "RAO failure");
     }
 }

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/CneFileExportServiceTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/CneFileExportServiceTest.java
@@ -275,7 +275,7 @@ class CneFileExportServiceTest {
     }
 
     @Test
-    void failureReasonExtractedFromRaoResultAndPutInXmlOutputFile() throws IOException, JAXBException {
+    void exportCneFromFailedRaoResult() throws IOException, JAXBException {
         final JAXBContext jaxbContext = JAXBContext.newInstance(CriticalNetworkElementMarketDocumentXmlRoot.class);
         final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 
@@ -284,10 +284,7 @@ class CneFileExportServiceTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         when(memDataSource.newOutputStream("targetZipFileName.xml", false)).thenReturn(baos);
-        when(dichotomyResult.getLowestInvalidStepValue()).thenReturn(42.);
-        when(dichotomyResult.getLowestInvalidStep()).thenReturn(lowestInvalidStep);
-        when(lowestInvalidStep.getRaoResult()).thenReturn(raoResult);
-        when(raoResult.getExecutionDetails()).thenReturn("test");
+        when(dichotomyResult.isRaoFailed()).thenReturn(true);
         when(sweData.getNetworkPtEs()).thenReturn(network);
         when(network.getCaseDate()).thenReturn(dateTime);
         when(cracCreationContext.getTimeStamp()).thenReturn(offsetDateTime);
@@ -320,6 +317,6 @@ class CneFileExportServiceTest {
                 .first()
                 .isInstanceOf(Reason.class)
                 .hasFieldOrPropertyWithValue("code", "B18")
-                .hasFieldOrPropertyWithValue("text", "test");
+                .hasFieldOrPropertyWithValue("text", "RAO failed");
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling by adding a URL parameter to track the lowest invalid step in dichotomy processing.
	- Improved context for Rao (Remedial Action Optimization) failure scenarios.

- **Refactor**
	- Restructured error handling and result processing in the CNE file export service.
	- Updated constructor and method signatures to support more detailed error tracking.

- **Tests**
	- Updated test cases to validate new error handling and URL tracking mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->