### PR TITLE
Check if swe response is interrupted before all rao failed

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/RequestService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/RequestService.java
@@ -69,12 +69,12 @@ public class RequestService {
     }
 
     private void sendSweResponse(SweResponse sweResponse) {
-        if (sweResponse.isAllRaoFailed()) {
-            businessLogger.warn("RAO failed for all computed directions");
-            sendTaskStatusUpdate(sweResponse.getId(), TaskStatus.ERROR);
-        } else if (sweResponse.isInterrupted()) {
+        if (sweResponse.isInterrupted()) {
             businessLogger.warn("SWE run has been interrupted");
             sendTaskStatusUpdate(sweResponse.getId(), TaskStatus.INTERRUPTED);
+        } else if (sweResponse.isAllRaoFailed()) {
+            businessLogger.warn("RAO failed for all computed directions");
+            sendTaskStatusUpdate(sweResponse.getId(), TaskStatus.ERROR);
         } else {
             sendTaskStatusUpdate(sweResponse.getId(), TaskStatus.SUCCESS);
         }

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/RequestServiceTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/RequestServiceTest.java
@@ -64,7 +64,7 @@ class RequestServiceTest {
     void testInterruptedRequestService() {
         String id = UUID.randomUUID().toString();
         SweRequest cseRequest = new SweRequest(id, "runId", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-        SweResponse cseResponse = new SweResponse(cseRequest.getId(), "null", true, false);
+        SweResponse cseResponse = new SweResponse(cseRequest.getId(), "null", true, true);
         byte[] req = jsonApiConverter.toJsonMessage(cseRequest, SweRequest.class);
         when(sweRunner.run(any())).thenReturn(cseResponse);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted internal processing to more accurately differentiate between interruptions and failures, ensuring reliable status updates.
  
- **Tests**
  - Updated scenarios to verify the improved behavior when operations experience interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->