### PR TITLE
Export the failing network files into the artifacts

### DIFF
--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/NetworkExporter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/NetworkExporter.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.gridcapa_swe_commons.shift;
+
+import com.powsybl.iidm.network.Network;
+
+/**
+ * @author Amira Kahya {@literal <amira.kahya at rte-france.com>}
+ */
+public interface NetworkExporter {
+    void export(Network network);
+}

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -51,8 +51,9 @@ public class SweNetworkShifter implements NetworkShifter {
     private final Map<String, Double> initialNetPositions;
     private final ProcessConfiguration processConfiguration;
     private final LoadFlowParameters loadFlowParameters;
+    private final NetworkExporter networkExporter;
 
-    public SweNetworkShifter(Logger businessLogger, ProcessType processType, DichotomyDirection direction, ZonalData<Scalable> zonalScalable, ShiftDispatcher shiftDispatcher, double toleranceEsPt, double toleranceEsFr, Map<String, Double> initialNetPositions, ProcessConfiguration processConfiguration, LoadFlowParameters loadFlowParameters) { // NOSONAR
+    public SweNetworkShifter(Logger businessLogger, ProcessType processType, DichotomyDirection direction, ZonalData<Scalable> zonalScalable, ShiftDispatcher shiftDispatcher, double toleranceEsPt, double toleranceEsFr, Map<String, Double> initialNetPositions, ProcessConfiguration processConfiguration, LoadFlowParameters loadFlowParameters, NetworkExporter networkExporter) { // NOSONAR
         this.businessLogger = businessLogger;
         this.processType = processType;
         this.direction = direction;
@@ -63,6 +64,7 @@ public class SweNetworkShifter implements NetworkShifter {
         this.initialNetPositions = initialNetPositions;
         this.processConfiguration = processConfiguration;
         this.loadFlowParameters = loadFlowParameters;
+        this.networkExporter = networkExporter;
     }
 
     @Override
@@ -99,6 +101,7 @@ public class SweNetworkShifter implements NetworkShifter {
                 if (result.isFailed()) {
                     LOGGER.error("Loadflow computation diverged on network '{}' for direction {}", network.getId(), direction.getDashName());
                     businessLogger.error("Loadflow computation diverged on network during balancing adjustment");
+                    networkExporter.export(network);
                     throw new ShiftingException("Loadflow computation diverged during balancing adjustment", ReasonInvalid.BALANCE_LOADFLOW_DIVERGENCE);
                 }
                 bordersExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -101,7 +101,9 @@ public class SweNetworkShifter implements NetworkShifter {
                 if (result.isFailed()) {
                     LOGGER.error("Loadflow computation diverged on network '{}' for direction {}", network.getId(), direction.getDashName());
                     businessLogger.error("Loadflow computation diverged on network during balancing adjustment");
-                    networkExporter.export(network);
+                    if (networkExporter != null) {
+                        networkExporter.export(network);
+                    }
                     throw new ShiftingException("Loadflow computation diverged during balancing adjustment", ReasonInvalid.BALANCE_LOADFLOW_DIVERGENCE);
                 }
                 bordersExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -80,7 +80,7 @@ class SweNetworkShifterTest {
     void checkD2ccEsFrTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.ES_FR, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), 0.001);
         assertEquals(1000., shifts.get("ES_FR"), 0.001);
@@ -90,7 +90,7 @@ class SweNetworkShifterTest {
     void checkD2ccFrEsTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.FR_ES, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.FR_ES, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), 0.001);
         assertEquals(-1000., shifts.get("ES_FR"), 0.001);
@@ -100,7 +100,7 @@ class SweNetworkShifterTest {
     void checkD2ccPtEsTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.PT_ES, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.PT_ES, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), 0.001);
         assertEquals(0., shifts.get("ES_FR"), 0.001);
@@ -110,7 +110,7 @@ class SweNetworkShifterTest {
     void checkD2ccEsPtTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.ES_PT, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.ES_PT, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), 0.001);
         assertEquals(0., shifts.get("ES_FR"), 0.001);
@@ -120,7 +120,7 @@ class SweNetworkShifterTest {
     void checkIdccEsFrTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.ES_FR, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.ES_FR, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), 0.001);
         assertEquals(1000., shifts.get("ES_FR"), 0.001);
@@ -130,7 +130,7 @@ class SweNetworkShifterTest {
     void checkIdccFrEsTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.FR_ES, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.FR_ES, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), 0.001);
         assertEquals(-1000., shifts.get("ES_FR"), 0.001);
@@ -140,7 +140,7 @@ class SweNetworkShifterTest {
     void checkIdccEsPtTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.ES_PT, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.ES_PT, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), 0.001);
         assertEquals(200, shifts.get("ES_FR"), 0.001);
@@ -150,7 +150,7 @@ class SweNetworkShifterTest {
     void checkIdccPtEsTargetExchangesCalculatedCorrectly() {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.PT_ES, null, null, 0., 0., intialNetPositions, null, null);
+                DichotomyDirection.PT_ES, null, null, 0., 0., intialNetPositions, null, null, null);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), 0.001);
         assertEquals(200., shifts.get("ES_FR"), 0.001);
@@ -162,7 +162,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(1000., network);
@@ -179,7 +179,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
@@ -190,7 +190,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(10820, network); // incomplete shift for ES in the first iteration , but no Glsk limitation error
@@ -207,7 +207,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(4645, network); // incomplete shift for FR in the first iteration , but no Glsk limitation error
@@ -224,7 +224,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4647, network));
@@ -237,7 +237,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_PT, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(3000., network));
     }
@@ -248,7 +248,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(1);
         assertThrows(ShiftingException.class, () -> sweNetworkShifter.shiftNetwork(1000., network));
     }
@@ -271,7 +271,7 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2310., SweEICode.FR_EIC, -2310., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(9050., network);
@@ -287,14 +287,14 @@ class SweNetworkShifterTest {
         Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 231., SweEICode.FR_EIC, -231., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
 
     @Test
     void updateScalingValuesWithMismatchPtEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load());
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -310,7 +310,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsPtTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load());
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -326,7 +326,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchFrEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load());
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -342,7 +342,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsFrTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load());
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -366,7 +366,7 @@ class SweNetworkShifterTest {
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -420,7 +420,7 @@ class SweNetworkShifterTest {
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.PT_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load());
+                DichotomyDirection.PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/configurations/ExportNetworkConfiguration.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/configurations/ExportNetworkConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.swe.runner.app.configurations;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Amira Kahya {@literal <amira.kahya at rte-france.com>}
+ */
+@Configuration
+@ConfigurationProperties(prefix = "swe-runner")
+public class ExportNetworkConfiguration {
+
+    private boolean exportFailedNetwork = false;
+
+    public boolean isExportFailedNetwork() {
+        return exportFailedNetwork;
+    }
+
+    public void setExportFailedNetwork(boolean exportFailedNetwork) {
+        this.exportFailedNetwork = exportFailedNetwork;
+    }
+}

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
@@ -12,14 +12,13 @@ import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfi
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.gridcapa_swe_commons.exception.SweBaseCaseUnsecureException;
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
-import com.farao_community.farao.gridcapa_swe_commons.shift.CountryBalanceComputation;
-import com.farao_community.farao.gridcapa_swe_commons.shift.SweD2ccShiftDispatcher;
-import com.farao_community.farao.gridcapa_swe_commons.shift.SweIdccShiftDispatcher;
-import com.farao_community.farao.gridcapa_swe_commons.shift.SweNetworkShifter;
-import com.farao_community.farao.gridcapa_swe_commons.shift.ZonalScalableProvider;
+import com.farao_community.farao.gridcapa_swe_commons.shift.*;
 import com.farao_community.farao.swe.runner.app.configurations.DichotomyConfiguration;
+import com.farao_community.farao.swe.runner.app.configurations.ExportNetworkConfiguration;
 import com.farao_community.farao.swe.runner.app.domain.SweData;
+import com.farao_community.farao.swe.runner.app.services.FileExporter;
 import com.farao_community.farao.swe.runner.app.services.NetworkService;
+import com.farao_community.farao.swe.runner.app.services.SweNetworkExporter;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
 import org.slf4j.Logger;
@@ -36,11 +35,15 @@ public class NetworkShifterProvider {
     private final DichotomyConfiguration dichotomyConfiguration;
     private final Logger businessLogger;
     private final ProcessConfiguration processConfiguration;
+    private final ExportNetworkConfiguration exportNetworkConfiguration;
+    private final FileExporter fileExporter;
 
-    public NetworkShifterProvider(DichotomyConfiguration dichotomyConfiguration, Logger businessLogger, ProcessConfiguration processConfiguration) {
+    public NetworkShifterProvider(DichotomyConfiguration dichotomyConfiguration, Logger businessLogger, ProcessConfiguration processConfiguration, ExportNetworkConfiguration exportNetworkConfiguration, FileExporter fileExporter) {
         this.dichotomyConfiguration = dichotomyConfiguration;
         this.businessLogger = businessLogger;
         this.processConfiguration = processConfiguration;
+        this.exportNetworkConfiguration = exportNetworkConfiguration;
+        this.fileExporter = fileExporter;
     }
 
     public NetworkShifter get(SweData sweData, DichotomyDirection direction, LoadFlowParameters loadFlowParameters) {
@@ -50,6 +53,7 @@ public class NetworkShifterProvider {
             Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, loadFlowParameters);
 
             businessLogger.info("Base case loadflow is secure");
+            SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork() ? new SweNetworkExporter(null, fileExporter) : null;
             return new SweNetworkShifter(businessLogger, sweData.getProcessType(), direction,
                     zonalScalableProvider.get(sweData.getGlskUrl(), network, sweData.getTimestamp()),
                     getShiftDispatcher(sweData.getProcessType(), direction, initialNetPositions),
@@ -57,7 +61,7 @@ public class NetworkShifterProvider {
                     dichotomyConfiguration.getParameters().get(direction).getToleranceEsFr(),
                     initialNetPositions,
                     processConfiguration,
-                    loadFlowParameters);
+                    loadFlowParameters, sweNetworkExporter);
         } catch (SweBaseCaseUnsecureException baseCaseUnsecureException) {
             businessLogger.error("Base case loadflow is unsecure, the calculation is stopped");
             throw baseCaseUnsecureException;

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
@@ -53,7 +53,7 @@ public class NetworkShifterProvider {
             Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, loadFlowParameters);
 
             businessLogger.info("Base case loadflow is secure");
-            SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork() ? new SweNetworkExporter(null, fileExporter) : null;
+            SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork() ? new SweNetworkExporter(sweData, fileExporter) : null;
             return new SweNetworkShifter(businessLogger, sweData.getProcessType(), direction,
                     zonalScalableProvider.get(sweData.getGlskUrl(), network, sweData.getTimestamp()),
                     getShiftDispatcher(sweData.getProcessType(), direction, initialNetPositions),

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/SweNetworkExporter.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/SweNetworkExporter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.swe.runner.app.services;
+
+import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
+import com.farao_community.farao.gridcapa_swe_commons.shift.NetworkExporter;
+import com.farao_community.farao.swe.runner.api.resource.SweRequest;
+import com.powsybl.iidm.network.Network;
+
+import java.time.OffsetDateTime;
+
+/**
+ * @author Amira Kahya {@literal <amira.kahya at rte-france.com>}
+ */
+public class SweNetworkExporter implements NetworkExporter {
+    private static final String XIIDM_EXTENSION = "xiidm";
+
+    private final SweRequest sweRequest;
+    private final FileExporter fileExporter;
+
+    public SweNetworkExporter(final SweRequest sweRequest, final FileExporter fileExporter) {
+        this.sweRequest = sweRequest;
+        this.fileExporter = fileExporter;
+    }
+
+    @Override
+    public void export(final Network network) {
+        final OffsetDateTime targetProcessDateTime = sweRequest.getTargetProcessDateTime();
+        final ProcessType processType = sweRequest.getProcessType();
+        final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
+        final String networkFilename = network.getNameOrId() + "-with-failed-balancing-adjustment." + XIIDM_EXTENSION;
+        fileExporter.saveNetworkInArtifact(network,
+                destinationMinioPath + networkFilename,
+                "",
+                targetProcessDateTime,
+                processType);
+    }
+}

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/SweNetworkExporter.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/SweNetworkExporter.java
@@ -8,7 +8,7 @@ package com.farao_community.farao.swe.runner.app.services;
 
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
 import com.farao_community.farao.gridcapa_swe_commons.shift.NetworkExporter;
-import com.farao_community.farao.swe.runner.api.resource.SweRequest;
+import com.farao_community.farao.swe.runner.app.domain.SweData;
 import com.powsybl.iidm.network.Network;
 
 import java.time.OffsetDateTime;
@@ -19,18 +19,18 @@ import java.time.OffsetDateTime;
 public class SweNetworkExporter implements NetworkExporter {
     private static final String XIIDM_EXTENSION = "xiidm";
 
-    private final SweRequest sweRequest;
+    private final SweData sweData;
     private final FileExporter fileExporter;
 
-    public SweNetworkExporter(final SweRequest sweRequest, final FileExporter fileExporter) {
-        this.sweRequest = sweRequest;
+    public SweNetworkExporter(final SweData sweData, final FileExporter fileExporter) {
+        this.sweData = sweData;
         this.fileExporter = fileExporter;
     }
 
     @Override
     public void export(final Network network) {
-        final OffsetDateTime targetProcessDateTime = sweRequest.getTargetProcessDateTime();
-        final ProcessType processType = sweRequest.getProcessType();
+        final OffsetDateTime targetProcessDateTime = sweData.getTimestamp();
+        final ProcessType processType = sweData.getProcessType();
         final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
         final String networkFilename = network.getNameOrId() + "-with-failed-balancing-adjustment." + XIIDM_EXTENSION;
         fileExporter.saveNetworkInArtifact(network,

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/SweNetworkExporter.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/SweNetworkExporter.java
@@ -9,6 +9,7 @@ package com.farao_community.farao.swe.runner.app.services;
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
 import com.farao_community.farao.gridcapa_swe_commons.shift.NetworkExporter;
 import com.farao_community.farao.swe.runner.app.domain.SweData;
+import com.farao_community.farao.swe.runner.app.utils.FaillingNetworkExportUtils;
 import com.powsybl.iidm.network.Network;
 
 import java.time.OffsetDateTime;
@@ -17,7 +18,6 @@ import java.time.OffsetDateTime;
  * @author Amira Kahya {@literal <amira.kahya at rte-france.com>}
  */
 public class SweNetworkExporter implements NetworkExporter {
-    private static final String XIIDM_EXTENSION = "xiidm";
 
     private final SweData sweData;
     private final FileExporter fileExporter;
@@ -31,12 +31,10 @@ public class SweNetworkExporter implements NetworkExporter {
     public void export(final Network network) {
         final OffsetDateTime targetProcessDateTime = sweData.getTimestamp();
         final ProcessType processType = sweData.getProcessType();
-        final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
-        final String networkFilename = network.getNameOrId() + "-with-failed-balancing-adjustment." + XIIDM_EXTENSION;
-        fileExporter.saveNetworkInArtifact(network,
-                destinationMinioPath + networkFilename,
-                "",
+        FaillingNetworkExportUtils.exportNetwork(network,
                 targetProcessDateTime,
-                processType);
+                processType,
+                fileExporter,
+                "-with-failed-balancing-adjustment");
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckService.java
@@ -15,6 +15,7 @@ import com.farao_community.farao.swe.runner.app.configurations.ExportNetworkConf
 import com.farao_community.farao.swe.runner.app.domain.SweData;
 import com.farao_community.farao.swe.runner.app.domain.SweDichotomyValidationData;
 import com.farao_community.farao.swe.runner.app.domain.SweTaskParameters;
+import com.farao_community.farao.swe.runner.app.utils.FaillingNetworkExportUtils;
 import com.farao_community.farao.swe.runner.app.utils.OpenLoadFlowParametersUtil;
 import com.farao_community.farao.swe.runner.app.utils.UrlValidationService;
 import com.powsybl.iidm.network.Network;
@@ -45,7 +46,6 @@ import java.util.Optional;
 
 @Service
 public class VoltageCheckService {
-    private static final String XIIDM_EXTENSION = "xiidm";
     private final Logger businessLogger;
     private final UrlValidationService urlValidationService;
     private final ExportNetworkConfiguration exportNetworkConfiguration;
@@ -53,7 +53,7 @@ public class VoltageCheckService {
 
     public VoltageCheckService(final Logger businessLogger,
                                final UrlValidationService urlValidationService,
-                               ExportNetworkConfiguration exportNetworkConfiguration,
+                               final ExportNetworkConfiguration exportNetworkConfiguration,
                                final FileExporter fileExporter) {
         this.businessLogger = businessLogger;
         this.urlValidationService = urlValidationService;
@@ -143,13 +143,7 @@ public class VoltageCheckService {
                                     final OffsetDateTime targetProcessDateTime,
                                     final ProcessType processType) {
         try {
-            final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
-            final String scaledNetworkInXiidmFormatName = network.getNameOrId() + "-with-failed-voltage-check." + XIIDM_EXTENSION;
-            fileExporter.saveNetworkInArtifact(network,
-                    destinationMinioPath + scaledNetworkInXiidmFormatName,
-                    "",
-                    targetProcessDateTime,
-                    processType);
+            FaillingNetworkExportUtils.exportNetwork(network, targetProcessDateTime, processType, fileExporter, "-with-failed-voltage-check");
         } catch (Exception e) {
             businessLogger.warn("Failed to export network with voltage constraint violations: {}", e.getMessage());
         }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckService.java
@@ -142,12 +142,16 @@ public class VoltageCheckService {
     private void exportXiidmNetwork(final Network network,
                                     final OffsetDateTime targetProcessDateTime,
                                     final ProcessType processType) {
-        final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
-        final String scaledNetworkInXiidmFormatName = network.getNameOrId() + "-with-failed-voltage-check." + XIIDM_EXTENSION;
-        fileExporter.saveNetworkInArtifact(network,
-                destinationMinioPath + scaledNetworkInXiidmFormatName,
-                "",
-                targetProcessDateTime,
-                processType);
+        try {
+            final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
+            final String scaledNetworkInXiidmFormatName = network.getNameOrId() + "-with-failed-voltage-check." + XIIDM_EXTENSION;
+            fileExporter.saveNetworkInArtifact(network,
+                    destinationMinioPath + scaledNetworkInXiidmFormatName,
+                    "",
+                    targetProcessDateTime,
+                    processType);
+        } catch (Exception e) {
+            businessLogger.warn("Failed to export network with voltage constraint violations: {}", e.getMessage());
+        }
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckService.java
@@ -9,6 +9,9 @@ package com.farao_community.farao.swe.runner.app.services;
 import com.farao_community.farao.dichotomy.api.results.DichotomyResult;
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.gridcapa_swe_commons.exception.SweInternalException;
+import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
+
+import com.farao_community.farao.swe.runner.app.configurations.ExportNetworkConfiguration;
 import com.farao_community.farao.swe.runner.app.domain.SweData;
 import com.farao_community.farao.swe.runner.app.domain.SweDichotomyValidationData;
 import com.farao_community.farao.swe.runner.app.domain.SweTaskParameters;
@@ -30,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -41,13 +45,20 @@ import java.util.Optional;
 
 @Service
 public class VoltageCheckService {
+    private static final String XIIDM_EXTENSION = "xiidm";
     private final Logger businessLogger;
     private final UrlValidationService urlValidationService;
+    private final ExportNetworkConfiguration exportNetworkConfiguration;
+    private final FileExporter fileExporter;
 
     public VoltageCheckService(final Logger businessLogger,
-                               final UrlValidationService urlValidationService) {
+                               final UrlValidationService urlValidationService,
+                               ExportNetworkConfiguration exportNetworkConfiguration,
+                               final FileExporter fileExporter) {
         this.businessLogger = businessLogger;
         this.urlValidationService = urlValidationService;
+        this.exportNetworkConfiguration = exportNetworkConfiguration;
+        this.fileExporter = fileExporter;
     }
 
     public Optional<RaoResultWithVoltageMonitoring> runVoltageCheck(final SweData sweData,
@@ -73,7 +84,7 @@ public class VoltageCheckService {
             final LoadFlowParameters loadFlowParameters = OpenLoadFlowParametersUtil.getLoadFlowParameters(sweTaskParameters);
             final MonitoringInput input = MonitoringInput.buildWithVoltage(network, crac, dichotomyResult.getHighestValidStep().getRaoResult()).build();
             final RaoResultWithVoltageMonitoring result = (RaoResultWithVoltageMonitoring) Monitoring.runVoltageAndUpdateRaoResult(LoadFlow.find().getName(), loadFlowParameters, 4, input);
-            generateHighAndLowVoltageConstraints(result, crac).forEach(businessLogger::warn);
+            generateHighAndLowVoltageConstraints(result, crac, network, sweData.getTimestamp(), sweData.getProcessType()).forEach(businessLogger::warn);
             return Optional.of(result);
         } catch (final Exception e) {
             businessLogger.error("Exception during voltage check : {}", e.getMessage());
@@ -82,7 +93,8 @@ public class VoltageCheckService {
     }
 
     protected List<String> generateHighAndLowVoltageConstraints(final RaoResultWithVoltageMonitoring result,
-                                                                final Crac crac) {
+                                                                final Crac crac, final Network network,
+                                                                final OffsetDateTime targetProcessDateTime, final ProcessType processType) {
         final List<String> voltageConstraints = new ArrayList<>();
         for (final VoltageCnec voltageCnec : crac.getVoltageCnecs()) {
             final Instant instant = voltageCnec.getState().getInstant();
@@ -90,6 +102,9 @@ public class VoltageCheckService {
                 voltageCnec.getLowerBound(Unit.KILOVOLT).ifPresent(lowerBound -> {
                     final double minVoltage = result.getMinVoltage(instant, voltageCnec, MinOrMax.MIN, Unit.KILOVOLT);
                     if (!Double.isNaN(minVoltage) && Double.compare(lowerBound, minVoltage) > 0) {
+                        if (exportNetworkConfiguration.isExportFailedNetwork()) {
+                            exportXiidmNetwork(network, targetProcessDateTime, processType);
+                        }
                         voltageConstraints.add(String.format(Locale.ENGLISH,
                                 "Low Voltage constraint reached - biggest violation on node \"%s\" - Minimum voltage of %f kV for a limit of %f kV",
                                 voltageCnec.getNetworkElement().getName(),
@@ -100,6 +115,9 @@ public class VoltageCheckService {
                 voltageCnec.getUpperBound(Unit.KILOVOLT).ifPresent(upperBound -> {
                     final double maxVoltage = result.getMaxVoltage(instant, voltageCnec, MinOrMax.MAX, Unit.KILOVOLT);
                     if (!Double.isNaN(maxVoltage) && Double.compare(maxVoltage, upperBound) > 0) {
+                        if (exportNetworkConfiguration.isExportFailedNetwork()) {
+                            exportXiidmNetwork(network, targetProcessDateTime, processType);
+                        }
                         voltageConstraints.add(String.format(Locale.ENGLISH,
                                 "High voltage constraint reached - biggest violation on node \"%s\" - Maximum voltage of %f kV for a limit of %f kV",
                                 voltageCnec.getNetworkElement().getName(),
@@ -119,5 +137,17 @@ public class VoltageCheckService {
         } catch (final IOException e) {
             throw new SweInternalException("Could not read network with PRA from RAO response during voltage check", e);
         }
+    }
+
+    private void exportXiidmNetwork(final Network network,
+                                    final OffsetDateTime targetProcessDateTime,
+                                    final ProcessType processType) {
+        final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
+        final String scaledNetworkInXiidmFormatName = network.getNameOrId() + "-with-failed-voltage-check." + XIIDM_EXTENSION;
+        fileExporter.saveNetworkInArtifact(network,
+                destinationMinioPath + scaledNetworkInXiidmFormatName,
+                "",
+                targetProcessDateTime,
+                processType);
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/utils/FaillingNetworkExportUtils.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/utils/FaillingNetworkExportUtils.java
@@ -1,0 +1,32 @@
+/*
+/*
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.farao_community.farao.swe.runner.app.utils;
+
+import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
+import com.farao_community.farao.swe.runner.app.services.FileExporter;
+import com.powsybl.iidm.network.Network;
+
+import java.time.OffsetDateTime;
+
+public final class FaillingNetworkExportUtils {
+    private static final String XIIDM_EXTENSION = "xiidm";
+
+    private FaillingNetworkExportUtils() {
+
+    }
+
+    public static void exportNetwork(Network network,
+                                     OffsetDateTime targetProcessDateTime,
+                                     ProcessType processType,
+                                     FileExporter fileExporter,
+                                     String filenameSuffix) {
+        final String destinationMinioPath = fileExporter.makeDestinationMinioPath(targetProcessDateTime, FileExporter.FileKind.ARTIFACTS);
+        final String filename = network.getNameOrId() + filenameSuffix + "." + XIIDM_EXTENSION;
+        fileExporter.saveNetworkInArtifact(network, destinationMinioPath + filename, "", targetProcessDateTime, processType);
+    }
+}

--- a/gridcapa-swe-runner-app/src/main/resources/application.yml
+++ b/gridcapa-swe-runner-app/src/main/resources/application.yml
@@ -29,3 +29,4 @@ swe-runner:
       PT_ES:
         tolerance-Es-Fr: 50
         tolerance-Es-Pt: 10
+  export-failed-network: false

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckServiceTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/VoltageCheckServiceTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.net.URISyntaxException;
 import java.time.OffsetDateTime;
@@ -54,7 +54,7 @@ class VoltageCheckServiceTest {
     @Autowired
     private VoltageCheckService service;
 
-    @MockBean
+    @MockitoBean
     private FileExporter fileExporter;
 
     private final SweTaskParameters sweTaskParameters = SweTaskParametersTestUtil.getSweTaskParameters();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to export network data when a load flow computation or voltage check fails, if enabled via configuration.
  - Introduced a configuration option to control exporting of failed networks.
  - Added a new network exporter implementation to save network data as artifacts.

- **Configuration**
  - New property `export-failed-network` (default: false) can be set in the application configuration to enable or disable failed network export.

- **Tests**
  - Updated tests to support new constructor and method signatures related to network exporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->