### PR TITLE
Do not export the results in case of interruption

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelization.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelization.java
@@ -48,8 +48,8 @@ public class DichotomyParallelization {
                                        final OffsetDateTime startTime) {
         final ExecutionResult<SweDichotomyResult> executionResult = runAndGetSweDichotomyResults(sweData, sweTaskParameters, startTime);
         dichotomyLogging.logEndAllDichotomies();
-        String ttcDocUrl = outputService.buildAndExportTtcDocument(sweData, executionResult);
         final boolean interrupted = executionResult.getResult().stream().anyMatch(SweDichotomyResult::isInterrupted);
+        String ttcDocUrl = !interrupted ? outputService.buildAndExportTtcDocument(sweData, executionResult) : "";
         interruptionService.removeRunToBeInterrupted(sweData.getId());
         final boolean allRaoFailed = executionResult.getResult().stream().allMatch(SweDichotomyResult::isRaoFailed);
         return new SweResponse(sweData.getId(), ttcDocUrl, interrupted, allRaoFailed);

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelization.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelization.java
@@ -49,7 +49,7 @@ public class DichotomyParallelization {
         final ExecutionResult<SweDichotomyResult> executionResult = runAndGetSweDichotomyResults(sweData, sweTaskParameters, startTime);
         dichotomyLogging.logEndAllDichotomies();
         final boolean interrupted = executionResult.getResult().stream().anyMatch(SweDichotomyResult::isInterrupted);
-        String ttcDocUrl = !interrupted ? outputService.buildAndExportTtcDocument(sweData, executionResult) : "";
+        final String ttcDocUrl = interrupted ? "" : outputService.buildAndExportTtcDocument(sweData, executionResult);
         interruptionService.removeRunToBeInterrupted(sweData.getId());
         final boolean allRaoFailed = executionResult.getResult().stream().allMatch(SweDichotomyResult::isRaoFailed);
         return new SweResponse(sweData.getId(), ttcDocUrl, interrupted, allRaoFailed);

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/parallelization/DichotomyParallelizationWorker.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/parallelization/DichotomyParallelizationWorker.java
@@ -72,6 +72,9 @@ public class DichotomyParallelizationWorker {
             final String lowestInvalidStepUrl = cneFileExportService.exportCneUrl(sweData, dichotomyResult, false, direction);
             return CompletableFuture.completedFuture(new SweDichotomyResult(direction, dichotomyResult, lowestInvalidStepUrl));
         }
+        if (dichotomyResult.isInterrupted()) {
+            return CompletableFuture.completedFuture(new SweDichotomyResult(direction, dichotomyResult, ""));
+        }
 
         // Generate files specific for one direction (cne, cgm, voltage) and add them to the returned object (to create)
         final String zippedLastSecureCgmesUrl = cgmesExportService.buildAndExportLastSecureCgmesFiles(direction, sweData, dichotomyResult, sweTaskParameters);

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelizationTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParallelizationTest.java
@@ -328,7 +328,6 @@ class DichotomyParallelizationTest {
         when(interruptedSweDichotomyResult.isInterrupted()).thenReturn(true);
 
         when(dichotomyRunner.run(any(SweData.class), any(SweTaskParameters.class), any(DichotomyDirection.class))).thenReturn(sweDichotomyResult);
-        when(outputService.buildAndExportTtcDocument(any(SweData.class), any(ExecutionResult.class))).thenReturn("ttcDocUrl");
         when(cgmesExportService.buildAndExportLastSecureCgmesFiles(any(), any(), any(), any())).thenReturn("ok");
         when(sweDichotomyResult.getHighestValidStep()).thenReturn(highestValidStep);
         when(highestValidStep.getRaoResult()).thenReturn(raoResult);
@@ -350,7 +349,7 @@ class DichotomyParallelizationTest {
         when(worker.runDichotomyForOneDirection(sweData, defaultParameters, DichotomyDirection.ES_PT, startingTime)).thenReturn(CompletableFuture.completedFuture(interruptedResult));
         when(worker.runDichotomyForOneDirection(sweData, defaultParameters, DichotomyDirection.PT_ES, startingTime)).thenReturn(CompletableFuture.completedFuture(interruptedResult));
         SweResponse sweResponse = dichotomyParallelization.launchDichotomy(sweData, defaultParameters, startingTime);
-        assertEquals("ttcDocUrl", sweResponse.getTtcDocUrl());
+        assertEquals("", sweResponse.getTtcDocUrl());
         assertTrue(sweResponse.isInterrupted());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The TTC document is no longer generated or linked if any dichotomy computation is interrupted, ensuring users do not receive incomplete or invalid TTC document URLs.

- **Tests**
  - Updated tests to verify that the TTC document URL is empty when interruptions occur during computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->