### PR TITLE
Avoid NPE when zonalScalable has no data during shift

### DIFF
--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/GeneratorLimitsHandler.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/GeneratorLimitsHandler.java
@@ -43,8 +43,9 @@ public class GeneratorLimitsHandler {
         initGenerators = new HashMap<>();
         countries.forEach(
                 country -> {
-                    if (zonalScalableData.getData(new EICode(country).getAreaCode()) != null) {
-                        zonalScalableData.getData(new EICode(country).getAreaCode()).filterInjections(network)
+                    final String areaCode = new EICode(country).getAreaCode();
+                    if (zonalScalableData.getData(areaCode) != null) {
+                        zonalScalableData.getData(areaCode).filterInjections(network)
                                 .stream()
                                 .filter(Generator.class::isInstance)
                                 .map(Generator.class::cast)

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/GeneratorLimitsHandler.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/GeneratorLimitsHandler.java
@@ -42,16 +42,20 @@ public class GeneratorLimitsHandler {
     public void setPminPmaxToDefaultValue(Network network, Set<Country> countries) {
         initGenerators = new HashMap<>();
         countries.forEach(
-            country -> zonalScalableData.getData(new EICode(country).getAreaCode()).filterInjections(network)
-                        .stream()
-                        .filter(Generator.class::isInstance)
-                        .map(Generator.class::cast)
-                        .filter(gen -> gen.getTerminal().getVoltageLevel().getSubstation().isPresent()
-                                && gen.getTerminal().getVoltageLevel().getSubstation().get().getCountry().equals(Optional.of(country)))
-                        .forEach(generator -> {
-                            saveInitLimits(generator);
-                            setLimitsToDefault(generator);
-                        }));
+                country -> {
+                    if (zonalScalableData.getData(new EICode(country).getAreaCode()) != null) {
+                        zonalScalableData.getData(new EICode(country).getAreaCode()).filterInjections(network)
+                                .stream()
+                                .filter(Generator.class::isInstance)
+                                .map(Generator.class::cast)
+                                .filter(gen -> gen.getTerminal().getVoltageLevel().getSubstation().isPresent()
+                                               && gen.getTerminal().getVoltageLevel().getSubstation().get().getCountry().equals(Optional.of(country)))
+                                .forEach(generator -> {
+                                    saveInitLimits(generator);
+                                    setLimitsToDefault(generator);
+                                });
+                    }
+                });
         LOGGER.info("Pmax and Pmin are set to default values for network {}", network.getNameOrId());
     }
 

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/ScalableGeneratorConnector.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/ScalableGeneratorConnector.java
@@ -66,8 +66,9 @@ public class ScalableGeneratorConnector {
      */
     private Set<Generator> getGeneratorsNotMainConnected(Network network,
                                                          Country country) {
-        if (zonalScalable.getData(new EICode(country).getAreaCode()) != null) {
-            return zonalScalable.getData(new EICode(country).getAreaCode()).filterInjections(network)
+        final String areaCode = new EICode(country).getAreaCode();
+        if (zonalScalable.getData(areaCode) != null) {
+            return zonalScalable.getData(areaCode).filterInjections(network)
                     .stream()
                     .filter(Generator.class::isInstance)
                     .map(Generator.class::cast)

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/ScalableGeneratorConnector.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/ScalableGeneratorConnector.java
@@ -64,14 +64,19 @@ public class ScalableGeneratorConnector {
      * Collects the list of generators of a given country, that are present in the scalable list, but not connected
      * to the network's main component
      */
-    private Set<Generator> getGeneratorsNotMainConnected(Network network, Country country) {
-        return zonalScalable.getData(new EICode(country).getAreaCode()).filterInjections(network)
-                .stream()
-                .filter(Generator.class::isInstance)
-                .map(Generator.class::cast)
-                .filter(gen -> gen.getTerminal().getVoltageLevel().getSubstation().isPresent()
-                        && gen.getTerminal().getVoltageLevel().getSubstation().get().getCountry().equals(Optional.of(country))
-                        && !getBus(gen.getTerminal()).isInMainConnectedComponent()).collect(Collectors.toSet());
+    private Set<Generator> getGeneratorsNotMainConnected(Network network,
+                                                         Country country) {
+        if (zonalScalable.getData(new EICode(country).getAreaCode()) != null) {
+            return zonalScalable.getData(new EICode(country).getAreaCode()).filterInjections(network)
+                    .stream()
+                    .filter(Generator.class::isInstance)
+                    .map(Generator.class::cast)
+                    .filter(gen -> gen.getTerminal().getVoltageLevel().getSubstation().isPresent()
+                                   && gen.getTerminal().getVoltageLevel().getSubstation().get().getCountry().equals(Optional.of(country))
+                                   && !getBus(gen.getTerminal()).isInMainConnectedComponent()).collect(Collectors.toSet());
+        } else {
+            return Set.of();
+        }
     }
 
     private static Bus getBus(Terminal terminal) {

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -158,15 +158,17 @@ public class SweNetworkShifter implements NetworkShifter {
         Map<String, Double> incompleteShiftCountries = new HashMap<>();
         for (Map.Entry<String, Double> entry : scalingValuesByCountry.entrySet()) {
             String zoneId = entry.getKey();
-            double asked = entry.getValue();
-            String logApplyingVariationOnZone = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
-            LOGGER.info(logApplyingVariationOnZone);
-            double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
-            if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
-                String logWarnIncompleteVariation = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
-                        direction, zoneId, asked, done);
-                LOGGER.warn(logWarnIncompleteVariation);
-                incompleteShiftCountries.put(zoneId, done - asked);
+            if (zonalScalable.getData(zoneId) != null) {
+                double asked = entry.getValue();
+                String logApplyingVariationOnZone = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
+                LOGGER.info(logApplyingVariationOnZone);
+                double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
+                if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
+                    String logWarnIncompleteVariation = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
+                                                                      direction, zoneId, asked, done);
+                    LOGGER.warn(logWarnIncompleteVariation);
+                    incompleteShiftCountries.put(zoneId, done - asked);
+                }
             }
         }
         // During the shift some generators linked to the main network with a transformers are not connected correctly


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically connects generators and transformers for predefined countries after each shift iteration to improve network readiness.

* **Bug Fixes**
  * Safely skips zones and countries with missing area data during shifting to prevent crashes.
  * Generator lookup now handles absent area data gracefully, returning empty results instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->