### PR TITLE
Fix crash when trying to export first unsecure when there is none

### DIFF
--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CgmesExportService.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/services/CgmesExportService.java
@@ -126,7 +126,7 @@ public class CgmesExportService {
                                                         final SweTaskParameters sweTaskParameters) {
         final DichotomyStepResult<SweDichotomyValidationData> lowestInvalidStep = dichotomyResult.getLowestInvalidStep();
 
-        if (lowestInvalidStep == null) {
+        if (lowestInvalidStep == null || lowestInvalidStep.getValidationData() == null) {
             businessLogger.error("Dichotomy does not have an invalid step, First Unsecure Shifted CGMES files won't be exported");
             return null;
         }

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/CgmesExportServiceTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/services/CgmesExportServiceTest.java
@@ -163,7 +163,9 @@ class CgmesExportServiceTest {
         final CgmesExportService spyCgmesExportService = spy(cgmesExportService);
         doReturn("Test").when(spyCgmesExportService).buildAndExportCgmesFiles(any(), any(), any(), any(), eq(false));
         final DichotomyResult<SweDichotomyValidationData> dichotomyResult = mock(DichotomyResult.class);
-        when(dichotomyResult.getLowestInvalidStep()).thenReturn(mock(DichotomyStepResult.class));
+        final DichotomyStepResult<SweDichotomyValidationData> mockStepResult = mock(DichotomyStepResult.class);
+        when(dichotomyResult.getLowestInvalidStep()).thenReturn(mockStepResult);
+        when(mockStepResult.getValidationData()).thenReturn(mock(SweDichotomyValidationData.class));
         final String result = spyCgmesExportService.buildAndExportFirstUnsecureCgmesFiles(DichotomyDirection.ES_FR, mock(SweData.class), dichotomyResult, mock(SweTaskParameters.class));
         assertEquals("Test", result);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents export failures in the First Unsecure CGMES files flow by handling missing validation data more safely, improving stability in edge cases.
* **Tests**
  * Refined tests to use typed mocks and explicit stubs for validation data, increasing reliability and clarity of test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->