### PR TITLE
Add new parameters to check GLSK limitations before load flow run

### DIFF
--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/CountryBalanceComputation.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/CountryBalanceComputation.java
@@ -6,23 +6,28 @@
  */
 package com.farao_community.farao.gridcapa_swe_commons.shift;
 
-import com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil;
 import com.farao_community.farao.gridcapa_swe_commons.exception.SweBaseCaseUnsecureException;
-import com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode;
 import com.powsybl.balances_adjustment.util.BorderBasedCountryArea;
 import com.powsybl.balances_adjustment.util.CountryAreaFactory;
-import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
-import com.powsybl.loadflow.LoadFlowResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil.runLoadFlowWithMdc;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.ES_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.FR_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.PT_EIC;
+import static com.powsybl.iidm.network.Country.ES;
+import static com.powsybl.iidm.network.Country.FR;
+import static com.powsybl.iidm.network.Country.PT;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
@@ -34,37 +39,36 @@ public final class CountryBalanceComputation {
         // Should not be instantiated
     }
 
-    public static Map<String, Double> computeSweCountriesBalances(Network network, LoadFlowParameters loadFlowParameters) {
+    public static Map<String, Double> computeSweCountriesBalances(final Network network, final LoadFlowParameters loadFlowParameters) {
         LOGGER.info("Computing initial SWE countries balance");
-        Map<String, Double> countriesBalances = new HashMap<>();
+        final Map<String, Double> countriesBalances = new HashMap<>();
         runLoadFlow(network, network.getVariantManager().getWorkingVariantId(), loadFlowParameters);
-        Map<String, Double> bordersExchanges = computeSweBordersExchanges(network);
-        countriesBalances.put(SweEICode.PT_EIC, -bordersExchanges.get("ES_PT"));
-        countriesBalances.put(SweEICode.ES_EIC, bordersExchanges.values().stream().reduce(0., Double::sum));
-        countriesBalances.put(SweEICode.FR_EIC, -bordersExchanges.get("ES_FR"));
+        final Map<String, Double> bordersExchanges = computeSweBordersExchanges(network);
+        countriesBalances.put(PT_EIC, -bordersExchanges.get("ES_PT"));
+        countriesBalances.put(ES_EIC, bordersExchanges.values().stream().reduce(0., Double::sum));
+        countriesBalances.put(FR_EIC, -bordersExchanges.get("ES_FR"));
 
         return countriesBalances;
     }
 
-    public static Map<String, Double> computeSweBordersExchanges(Network network) {
-        Map<String, Double> borderExchanges = new HashMap<>();
-        Map<Country, BorderBasedCountryArea> countryAreaPerCountry = Stream.of(Country.FR, Country.ES, Country.PT)
-                .collect(Collectors.toMap(Function.identity(), country -> (BorderBasedCountryArea) new CountryAreaFactory(country).create(network)));
-        borderExchanges.put("ES_FR", getBorderExchange(Country.ES, Country.FR, countryAreaPerCountry));
-        borderExchanges.put("ES_PT", getBorderExchange(Country.ES, Country.PT, countryAreaPerCountry));
+    public static Map<String, Double> computeSweBordersExchanges(final Network network) {
+        final Map<String, Double> borderExchanges = new HashMap<>();
+        final Map<Country, BorderBasedCountryArea> countryAreaPerCountry = Stream.of(FR, ES, PT)
+                .collect(toMap(Function.identity(),
+                               country -> (BorderBasedCountryArea) new CountryAreaFactory(country).create(network)));
+        borderExchanges.put("ES_FR", getBorderExchange(ES, FR, countryAreaPerCountry));
+        borderExchanges.put("ES_PT", getBorderExchange(ES, PT, countryAreaPerCountry));
         return borderExchanges;
     }
 
     private static void runLoadFlow(final Network network, final String workingStateId, final LoadFlowParameters loadFlowParameters) {
-        final LoadFlowResult result = LoadFlowUtil.runLoadFlowWithMdc(network, workingStateId, loadFlowParameters);
-
-        if (result.isFailed()) {
+        if (runLoadFlowWithMdc(network, workingStateId, loadFlowParameters).isFailed()) {
             LOGGER.error("Loadflow computation diverged on network '{}'", network.getId());
             throw new SweBaseCaseUnsecureException(String.format("Loadflow computation diverged on network %s", network.getId()));
         }
     }
 
-    private static double getBorderExchange(Country fromCountry, Country toCountry, Map<Country, BorderBasedCountryArea> countryAreaPerCountry) {
-        return countryAreaPerCountry.get(fromCountry).getLeavingFlowToCountry(countryAreaPerCountry.get(toCountry));
+    private static double getBorderExchange(final Country origin, final Country destination, final Map<Country, BorderBasedCountryArea> countryAreaByCountry) {
+        return countryAreaByCountry.get(origin).getLeavingFlowToCountry(countryAreaByCountry.get(destination));
     }
 }

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/CountryBalanceComputation.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/CountryBalanceComputation.java
@@ -7,11 +7,13 @@
 package com.farao_community.farao.gridcapa_swe_commons.shift;
 
 import com.farao_community.farao.gridcapa_swe_commons.exception.SweBaseCaseUnsecureException;
+import com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil;
 import com.powsybl.balances_adjustment.util.BorderBasedCountryArea;
 import com.powsybl.balances_adjustment.util.CountryAreaFactory;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +22,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil.runLoadFlowWithMdc;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.ES_EIC;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.FR_EIC;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.PT_EIC;
@@ -62,13 +63,15 @@ public final class CountryBalanceComputation {
     }
 
     private static void runLoadFlow(final Network network, final String workingStateId, final LoadFlowParameters loadFlowParameters) {
-        if (runLoadFlowWithMdc(network, workingStateId, loadFlowParameters).isFailed()) {
+        final LoadFlowResult result = LoadFlowUtil.runLoadFlowWithMdc(network, workingStateId, loadFlowParameters);
+
+        if (result.isFailed()) {
             LOGGER.error("Loadflow computation diverged on network '{}'", network.getId());
             throw new SweBaseCaseUnsecureException(String.format("Loadflow computation diverged on network %s", network.getId()));
         }
     }
 
-    private static double getBorderExchange(final Country origin, final Country destination, final Map<Country, BorderBasedCountryArea> countryAreaByCountry) {
-        return countryAreaByCountry.get(origin).getLeavingFlowToCountry(countryAreaByCountry.get(destination));
+    private static double getBorderExchange(final Country from, final Country to, final Map<Country, BorderBasedCountryArea> countryAreaByCountry) {
+        return countryAreaByCountry.get(from).getLeavingFlowToCountry(countryAreaByCountry.get(to));
     }
 }

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/CountryBalanceComputation.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/CountryBalanceComputation.java
@@ -40,7 +40,8 @@ public final class CountryBalanceComputation {
         // Should not be instantiated
     }
 
-    public static Map<String, Double> computeSweCountriesBalances(final Network network, final LoadFlowParameters loadFlowParameters) {
+    public static Map<String, Double> computeSweCountriesBalances(final Network network,
+                                                                  final LoadFlowParameters loadFlowParameters) {
         LOGGER.info("Computing initial SWE countries balance");
         final Map<String, Double> countriesBalances = new HashMap<>();
         runLoadFlow(network, network.getVariantManager().getWorkingVariantId(), loadFlowParameters);
@@ -54,15 +55,20 @@ public final class CountryBalanceComputation {
 
     public static Map<String, Double> computeSweBordersExchanges(final Network network) {
         final Map<String, Double> borderExchanges = new HashMap<>();
+
+        final Function<Country, BorderBasedCountryArea> countryToBbArea =
+            country -> (BorderBasedCountryArea) new CountryAreaFactory(country).create(network);
+
         final Map<Country, BorderBasedCountryArea> countryAreaPerCountry = Stream.of(FR, ES, PT)
-                .collect(toMap(Function.identity(),
-                               country -> (BorderBasedCountryArea) new CountryAreaFactory(country).create(network)));
+            .collect(toMap(Function.identity(), countryToBbArea));
         borderExchanges.put("ES_FR", getBorderExchange(ES, FR, countryAreaPerCountry));
         borderExchanges.put("ES_PT", getBorderExchange(ES, PT, countryAreaPerCountry));
         return borderExchanges;
     }
 
-    private static void runLoadFlow(final Network network, final String workingStateId, final LoadFlowParameters loadFlowParameters) {
+    private static void runLoadFlow(final Network network,
+                                    final String workingStateId,
+                                    final LoadFlowParameters loadFlowParameters) {
         final LoadFlowResult result = LoadFlowUtil.runLoadFlowWithMdc(network, workingStateId, loadFlowParameters);
 
         if (result.isFailed()) {
@@ -71,7 +77,9 @@ public final class CountryBalanceComputation {
         }
     }
 
-    private static double getBorderExchange(final Country from, final Country to, final Map<Country, BorderBasedCountryArea> countryAreaByCountry) {
+    private static double getBorderExchange(final Country from,
+                                            final Country to,
+                                            final Map<Country, BorderBasedCountryArea> countryAreaByCountry) {
         return countryAreaByCountry.get(from).getLeavingFlowToCountry(countryAreaByCountry.get(to));
     }
 }

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.farao_community.farao.dichotomy.api.results.ReasonInvalid.BALANCE_LOADFLOW_DIVERGENCE;
@@ -87,7 +88,8 @@ public class SweNetworkShifter implements NetworkShifter {
     }
 
     @Override
-    public void shiftNetwork(final double stepValue, final Network network) throws GlskLimitationException, ShiftingException {
+    public void shiftNetwork(final double stepValue,
+                             final Network network) throws GlskLimitationException, ShiftingException {
         final VariantManager variantManager = network.getVariantManager();
         businessLogger.info("Starting shift on network {}", variantManager.getWorkingVariantId());
         final Map<String, Double> scalingValuesByCountry = shiftDispatcher.dispatch(stepValue);
@@ -117,7 +119,7 @@ public class SweNetworkShifter implements NetworkShifter {
             do {
                 // Step 1: Perform the scaling
                 LOGGER.info("[{}] : Applying shift iteration {} ", direction, iterationCounter);
-                final Map<String, Double> incompleteShiftCountries = shiftIteration(
+                final Map<String, Double> incompleteShiftCountries = iterateOnShift(
                     network, scalingValuesByCountry, scalingParameters, scalableGeneratorConnector
                 );
                 // Step 2: Compute exchanges mismatch
@@ -138,15 +140,15 @@ public class SweNetworkShifter implements NetworkShifter {
                 // Step 3: Checks GLSK limitation and balance adjustment results
 
                 if (runGlskChecksBeforeLoadFlow) {
-                    checkGlskLimitation(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
+                    checkGlskLimitations(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
                 }
-                if (hasShiftSucceeded(mismatchEsPt, mismatchEsFr)) {
+                if (isWithinTolerances(mismatchEsPt, mismatchEsFr)) {
                     logShiftSuccess(iterationCounter, bordersExchanges);
                     variantManager.cloneVariant(workingVariantCopyId, initialVariantId, true);
                     shiftSucceeded = true;
                 } else {
                     if (!runGlskChecksBeforeLoadFlow) {
-                        checkGlskLimitation(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
+                        checkGlskLimitations(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
                     }
                     // Reset current variant with initial state for each iteration (keeping pre-processing)
                     variantManager.cloneVariant(processedVariantId, workingVariantCopyId, true);
@@ -175,7 +177,8 @@ public class SweNetworkShifter implements NetworkShifter {
         }
     }
 
-    private void logShiftSuccess(final int iterationCounter, final Map<String, Double> bordersExchanges) {
+    private void logShiftSuccess(final int iterationCounter,
+                                 final Map<String, Double> bordersExchanges) {
         final String logShiftSucceeded = String.format(
             "[%s] : Shift succeeded after %s iteration ", direction, iterationCounter
         );
@@ -187,61 +190,73 @@ public class SweNetworkShifter implements NetworkShifter {
         businessLogger.info(infoMessage);
     }
 
-    private boolean hasShiftSucceeded(final double mismatchEsPt, final double mismatchEsFr) {
+    private boolean isWithinTolerances(final double mismatchEsPt,
+                                       final double mismatchEsFr) {
         return Math.abs(mismatchEsPt) < toleranceEsPt && Math.abs(mismatchEsFr) < toleranceEsFr;
     }
 
-    private Map<String, Double> shiftIteration(final Network network,
+    private Map<String, Double> iterateOnShift(final Network network,
                                                final Map<String, Double> scalingValuesByCountry,
                                                final ScalingParameters scalingParameters,
                                                final ScalableGeneratorConnector scalableGeneratorConnector) {
         final Map<String, Double> incompleteShiftCountries = new HashMap<>();
-        for (final Map.Entry<String, Double> entry : scalingValuesByCountry.entrySet()) {
-            final String zoneId = entry.getKey();
-            if (zonalScalable.getData(zoneId) != null) {
-                double asked = entry.getValue();
-                final String infoMessage = String.format(
-                    "[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked
-                );
-                LOGGER.info(infoMessage);
-                double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
-                if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
-                    final String warningMessage = String.format(
-                        "[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)", direction, zoneId, asked, done
-                    );
-                    LOGGER.warn(warningMessage);
-                    incompleteShiftCountries.put(zoneId, done - asked);
-                }
-            }
-        }
+        scalingValuesByCountry
+            .forEach((zoneId, asked) ->
+                         computeShift(zoneId, asked, network, scalingParameters)
+                             .ifPresent(shift -> incompleteShiftCountries.put(zoneId, shift)));
+
         // During the shift some generators linked to the main network with a transformers are not connected correctly
         // Waiting for a fix in powsybl-core, we connect the transformers linked to these generators to be correctly connected to the main network component
         scalableGeneratorConnector.connectGeneratorsTransformers(network, PRE_PROCESSING_COUNTRIES);
         return incompleteShiftCountries;
     }
 
-    private void checkGlskLimitation(final Map<String, Double> incompleteShiftCountries,
-                                     final double mismatchEsPt,
-                                     final double mismatchEsFr) throws GlskLimitationException {
+    private Optional<Double> computeShift(final String zoneId,
+                                          final Double asked,
+                                          final Network network,
+                                          final ScalingParameters scalingParameters) {
+        if (zonalScalable.getData(zoneId) == null) {
+            return Optional.empty();
+        }
+        final String infoMessage = String.format(
+            "[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked
+        );
+        LOGGER.info(infoMessage);
+        double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
+        if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
+            final String warningMessage = String.format(
+                "[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)", direction, zoneId, asked, done
+            );
+            LOGGER.warn(warningMessage);
+            return Optional.of(done - asked);
+
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private void checkGlskLimitations(final Map<String, Double> incompleteShiftCountries,
+                                      final double mismatchEsPt,
+                                      final double mismatchEsFr) throws GlskLimitationException {
 
         final Double ptDiff = incompleteShiftCountries.get(PT_EIC);
         final Double frDiff = incompleteShiftCountries.get(FR_EIC);
         final Double esDiff = incompleteShiftCountries.get(ES_EIC);
 
         if (ptDiff != null) {
-            checkGlskLimitationCountry("PT", ptDiff, mismatchEsPt);
+            checkGlskLimitation("PT", ptDiff, mismatchEsPt);
         }
         if (frDiff != null) {
-            checkGlskLimitationCountry("FR", frDiff, mismatchEsFr);
+            checkGlskLimitation("FR", frDiff, mismatchEsFr);
         }
         if (esDiff != null) {
-            checkGlskLimitationCountry("ES", esDiff, -(mismatchEsFr + mismatchEsPt));
+            checkGlskLimitation("ES", esDiff, -(mismatchEsFr + mismatchEsPt));
         }
     }
 
-    private void checkGlskLimitationCountry(final String country,
-                                            final double diffShift,
-                                            final double mismatch) throws GlskLimitationException {
+    private void checkGlskLimitation(final String country,
+                                     final double diffShift,
+                                     final double mismatch) throws GlskLimitationException {
         // In case of asked > 0 : (done - asked) will be < 0, we have GLSK limitation if the next asked value increase (mismatch < 0),
         // In case of asked < 0 : (done - asked) will be > 0, we have GLSK limitation if the next asked value decrease (mismatch > 0)
         if (diffShift < 0 && mismatch < 0 || diffShift > 0 && mismatch > 0) {
@@ -282,13 +297,17 @@ public class SweNetworkShifter implements NetworkShifter {
                                                 final double mismatchEsPt,
                                                 final double mismatchEsFr) {
         switch (direction) {
-            case ES_FR, FR_ES ->
-                scalingValuesByCountry.computeIfPresent(FR_EIC, (k, frValue) -> frValue - mismatchEsFr);
-            case ES_PT, PT_ES ->
-                scalingValuesByCountry.computeIfPresent(PT_EIC, (k, ptValue) -> ptValue - mismatchEsPt);
+            case ES_FR, FR_ES -> scalingValuesByCountry.computeIfPresent(
+                FR_EIC, (k, frValue) -> frValue - mismatchEsFr
+            );
+            case ES_PT, PT_ES -> scalingValuesByCountry.computeIfPresent(
+                PT_EIC, (k, ptValue) -> ptValue - mismatchEsPt
+            );
         }
 
-        scalingValuesByCountry.computeIfPresent(ES_EIC, (k, esValue) -> esValue + mismatchEsPt + mismatchEsFr);
+        scalingValuesByCountry.computeIfPresent(
+            ES_EIC, (k, esValue) -> esValue + mismatchEsPt + mismatchEsFr
+        );
     }
 
     public Map<String, Double> getTargetExchanges(final double stepValue) {

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -9,7 +9,6 @@ package com.farao_community.farao.gridcapa_swe_commons.shift;
 import com.farao_community.farao.dichotomy.api.NetworkShifter;
 import com.farao_community.farao.dichotomy.api.exceptions.GlskLimitationException;
 import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
-import com.farao_community.farao.dichotomy.api.results.ReasonInvalid;
 import com.farao_community.farao.dichotomy.shift.ShiftDispatcher;
 import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfiguration;
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
@@ -29,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static com.farao_community.farao.dichotomy.api.results.ReasonInvalid.BALANCE_LOADFLOW_DIVERGENCE;
 import static com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil.runLoadFlowWithMdc;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType.D2CC;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.ES_EIC;
@@ -96,21 +96,20 @@ public class SweNetworkShifter implements NetworkShifter {
         final GeneratorLimitsHandler generatorLimitsHandler = new GeneratorLimitsHandler(zonalScalable);
 
         try {
-            final String logTargetCountriesShift = String.format("Target countries shift [ES = %.2f, FR = %.2f, PT = %.2f]",
-                                                                 scalingValuesByCountry.get(ES_EIC), scalingValuesByCountry.get(FR_EIC), scalingValuesByCountry.get(PT_EIC));
-            businessLogger.info(logTargetCountriesShift);
+            final String targetCountriesShiftMessage = String.format(
+                "Target countries shift [ES = %.2f, FR = %.2f, PT = %.2f]", scalingValuesByCountry.get(ES_EIC), scalingValuesByCountry.get(FR_EIC), scalingValuesByCountry.get(PT_EIC)
+            );
+            businessLogger.info(targetCountriesShiftMessage);
+
             final Map<String, Double> targetExchanges = getTargetExchanges(stepValue);
             int iterationCounter = 1;
             boolean shiftSucceeded = false;
             final String initialVariantId = variantManager.getWorkingVariantId();
             final String processedVariantId = initialVariantId + " PROCESSED COPY";
             final String workingVariantCopyId = initialVariantId + " WORKING COPY";
-            preProcessNetwork(network,
-                              scalableGeneratorConnector,
-                              generatorLimitsHandler,
-                              initialVariantId,
-                              processedVariantId,
-                              workingVariantCopyId);
+            preProcessNetwork(
+                network, scalableGeneratorConnector, generatorLimitsHandler, initialVariantId, processedVariantId, workingVariantCopyId
+            );
             Map<String, Double> bordersExchanges;
             final int maxIterationNumber = processConfiguration.getShiftMaxIterationNumber();
             final ScalingParameters scalingParameters = getScalingParameters();
@@ -118,11 +117,9 @@ public class SweNetworkShifter implements NetworkShifter {
             do {
                 // Step 1: Perform the scaling
                 LOGGER.info("[{}] : Applying shift iteration {} ", direction, iterationCounter);
-                final Map<String, Double> incompleteShiftCountries = shiftIteration(network,
-                                                                                    scalingValuesByCountry,
-                                                                                    scalingParameters,
-                                                                                    scalableGeneratorConnector,
-                                                                                    stepValue);
+                final Map<String, Double> incompleteShiftCountries = shiftIteration(
+                    network, scalingValuesByCountry, scalingParameters, scalableGeneratorConnector
+                );
                 // Step 2: Compute exchanges mismatch
                 final LoadFlowResult result = runLoadFlowWithMdc(network, workingVariantCopyId, loadFlowParameters);
                 if (result.isFailed()) {
@@ -131,7 +128,7 @@ public class SweNetworkShifter implements NetworkShifter {
                     if (networkExporter != null) {
                         networkExporter.export(network);
                     }
-                    throw new ShiftingException("Loadflow computation diverged during balancing adjustment", ReasonInvalid.BALANCE_LOADFLOW_DIVERGENCE);
+                    throw new ShiftingException("Loadflow computation diverged during balancing adjustment", BALANCE_LOADFLOW_DIVERGENCE);
                 }
 
                 bordersExchanges = computeSweBordersExchanges(network);
@@ -161,8 +158,9 @@ public class SweNetworkShifter implements NetworkShifter {
 
             // Step 4 : check after iteration max and out of tolerance
             if (!shiftSucceeded) {
-                String message = String.format("Balancing adjustment out of tolerances : Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f",
-                                               bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR));
+                final String message = String.format(
+                    "Balancing adjustment out of tolerances : Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f", bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR)
+                );
                 businessLogger.error(message);
                 throw new ShiftingException(message);
             }
@@ -179,13 +177,15 @@ public class SweNetworkShifter implements NetworkShifter {
 
     private void logShiftSuccess(final int iterationCounter,
                                  final Map<String, Double> bordersExchanges) {
-        final String logShiftSucceeded = String.format("[%s] : Shift succeeded after %s iteration ",
-                                                       direction, iterationCounter);
+        final String logShiftSucceeded = String.format(
+            "[%s] : Shift succeeded after %s iteration ", direction, iterationCounter
+        );
         LOGGER.info(logShiftSucceeded);
         businessLogger.info("Shift succeeded after {} iteration ", iterationCounter);
-        final String info = String.format("Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f",
-                                          bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR));
-        businessLogger.info(info);
+        final String infoMessage = String.format(
+            "Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f", bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR)
+        );
+        businessLogger.info(infoMessage);
     }
 
     private boolean hasShiftSucceeded(final double mismatchEsPt,
@@ -196,19 +196,21 @@ public class SweNetworkShifter implements NetworkShifter {
     private Map<String, Double> shiftIteration(final Network network,
                                                final Map<String, Double> scalingValuesByCountry,
                                                final ScalingParameters scalingParameters,
-                                               final ScalableGeneratorConnector scalableGeneratorConnector,
-                                               final double stepValue) throws GlskLimitationException {
+                                               final ScalableGeneratorConnector scalableGeneratorConnector) {
         final Map<String, Double> incompleteShiftCountries = new HashMap<>();
         for (final Map.Entry<String, Double> entry : scalingValuesByCountry.entrySet()) {
             final String zoneId = entry.getKey();
             if (zonalScalable.getData(zoneId) != null) {
                 double asked = entry.getValue();
-                final String infoMessage = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
+                final String infoMessage = String.format(
+                    "[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked
+                );
                 LOGGER.info(infoMessage);
                 double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
                 if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
-                    final String warningMessage = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
-                                                                      direction, zoneId, asked, done);
+                    final String warningMessage = String.format(
+                        "[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)", direction, zoneId, asked, done
+                    );
                     LOGGER.warn(warningMessage);
                     incompleteShiftCountries.put(zoneId, done - asked);
                 }
@@ -242,8 +244,8 @@ public class SweNetworkShifter implements NetworkShifter {
     private void checkGlskLimitationCountry(final String country,
                                             final double diffShift,
                                             final double mismatch) throws GlskLimitationException {
-        // In case of asked > 0 : (done - asked) will be < 0, we have Glsk limitation if the next asked value increase (mismatch < 0),
-        // In case of asked < 0 : (done - asked) will be > 0, we have Glsk limitation if the next asked value decrease (mismatch > 0)
+        // In case of asked > 0 : (done - asked) will be < 0, we have GLSK limitation if the next asked value increase (mismatch < 0),
+        // In case of asked < 0 : (done - asked) will be > 0, we have GLSK limitation if the next asked value decrease (mismatch > 0)
         if (diffShift < 0 && mismatch < 0 || diffShift > 0 && mismatch > 0) {
             final String errorMessage = "GLSK limitation occurred for country " + country;
             businessLogger.error(errorMessage);
@@ -282,30 +284,35 @@ public class SweNetworkShifter implements NetworkShifter {
                                                 final double mismatchEsPt,
                                                 final double mismatchEsFr) {
         switch (direction) {
-            case ES_FR, FR_ES -> scalingValuesByCountry.put(FR_EIC, scalingValuesByCountry.get(FR_EIC) - mismatchEsFr);
-            case ES_PT, PT_ES -> scalingValuesByCountry.put(PT_EIC, scalingValuesByCountry.get(PT_EIC) - mismatchEsPt);
+            case ES_FR, FR_ES ->
+                scalingValuesByCountry.computeIfPresent(FR_EIC, (k, frValue) -> frValue - mismatchEsFr);
+            case ES_PT, PT_ES ->
+                scalingValuesByCountry.computeIfPresent(PT_EIC, (k, ptValue) -> ptValue - mismatchEsPt);
         }
 
-        scalingValuesByCountry.put(ES_EIC, scalingValuesByCountry.get(ES_EIC) + mismatchEsPt + mismatchEsFr);
+        scalingValuesByCountry.computeIfPresent(ES_EIC, (k, esValue) -> esValue + mismatchEsPt + mismatchEsFr);
     }
 
     public Map<String, Double> getTargetExchanges(final double stepValue) {
-        return processType == D2CC ? getDayAheadTargetExchanges(stepValue) : getIdccTargetExchanges(stepValue, initialNetPositions);
+        return processType == D2CC
+            ? getD2ccTargetExchanges(stepValue)
+            : getIdccTargetExchanges(stepValue, initialNetPositions);
     }
 
     private Map<String, Double> getIdccTargetExchanges(final double stepValue,
                                                        final Map<String, Double> initialNetPositions) {
+        final double ptNetPosition = initialNetPositions.get(PT_EIC);
+        final double esNetPosition = initialNetPositions.get(ES_EIC);
+
         return switch (direction) {
-            case ES_FR -> Map.of(ES_PT, -initialNetPositions.get(PT_EIC), ES_FR, stepValue);
-            case FR_ES -> Map.of(ES_PT, -initialNetPositions.get(PT_EIC), ES_FR, -stepValue);
-            case ES_PT ->
-                Map.of(ES_PT, stepValue, ES_FR, initialNetPositions.get(ES_EIC) + initialNetPositions.get(PT_EIC));
-            case PT_ES ->
-                Map.of(ES_PT, -stepValue, ES_FR, initialNetPositions.get(ES_EIC) + initialNetPositions.get(PT_EIC));
+            case ES_FR -> Map.of(ES_PT, -ptNetPosition, ES_FR, stepValue);
+            case FR_ES -> Map.of(ES_PT, -ptNetPosition, ES_FR, -stepValue);
+            case ES_PT -> Map.of(ES_PT, stepValue, ES_FR, esNetPosition + ptNetPosition);
+            case PT_ES -> Map.of(ES_PT, -stepValue, ES_FR, esNetPosition + ptNetPosition);
         };
     }
 
-    private Map<String, Double> getDayAheadTargetExchanges(final double stepValue) {
+    private Map<String, Double> getD2ccTargetExchanges(final double stepValue) {
         return switch (direction) {
             case ES_FR -> Map.of(ES_PT, 0., ES_FR, stepValue);
             case FR_ES -> Map.of(ES_PT, 0., ES_FR, -stepValue);

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -58,7 +58,7 @@ public class SweNetworkShifter implements NetworkShifter {
     private final ProcessConfiguration processConfiguration;
     private final LoadFlowParameters loadFlowParameters;
     private final NetworkExporter networkExporter;
-    private final boolean runGlskChecksFirst;
+    private final boolean runGlskChecksBeforeLoadFlow;
 
     public SweNetworkShifter(final Logger businessLogger,
                              final ProcessType processType,
@@ -71,7 +71,7 @@ public class SweNetworkShifter implements NetworkShifter {
                              final ProcessConfiguration processConfiguration,
                              final LoadFlowParameters loadFlowParameters,
                              final NetworkExporter networkExporter,
-                             final boolean runGlskChecksFirst) { // NOSONAR
+                             final boolean runGlskChecksBeforeLoadFlow) { // NOSONAR
         this.businessLogger = businessLogger;
         this.processType = processType;
         this.direction = direction;
@@ -83,7 +83,7 @@ public class SweNetworkShifter implements NetworkShifter {
         this.processConfiguration = processConfiguration;
         this.loadFlowParameters = loadFlowParameters;
         this.networkExporter = networkExporter;
-        this.runGlskChecksFirst = runGlskChecksFirst;
+        this.runGlskChecksBeforeLoadFlow = runGlskChecksBeforeLoadFlow;
     }
 
     @Override
@@ -140,7 +140,7 @@ public class SweNetworkShifter implements NetworkShifter {
 
                 // Step 3: Checks GLSK limitation and balance adjustment results
 
-                if (runGlskChecksFirst) {
+                if (runGlskChecksBeforeLoadFlow) {
                     checkGlskLimitation(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
                 }
                 if (hasShiftSucceeded(mismatchEsPt, mismatchEsFr)) {
@@ -148,7 +148,7 @@ public class SweNetworkShifter implements NetworkShifter {
                     variantManager.cloneVariant(workingVariantCopyId, initialVariantId, true);
                     shiftSucceeded = true;
                 } else {
-                    if (!runGlskChecksFirst) {
+                    if (!runGlskChecksBeforeLoadFlow) {
                         checkGlskLimitation(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
                     }
                     // Reset current variant with initial state for each iteration (keeping pre-processing)
@@ -203,13 +203,13 @@ public class SweNetworkShifter implements NetworkShifter {
             final String zoneId = entry.getKey();
             if (zonalScalable.getData(zoneId) != null) {
                 double asked = entry.getValue();
-                final String info = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
-                LOGGER.info(info);
+                final String infoMessage = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
+                LOGGER.info(infoMessage);
                 double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
                 if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
-                    String warning = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
+                    final String warningMessage = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
                                                                       direction, zoneId, asked, done);
-                    LOGGER.warn(warning);
+                    LOGGER.warn(warningMessage);
                     incompleteShiftCountries.put(zoneId, done - asked);
                 }
             }
@@ -245,9 +245,9 @@ public class SweNetworkShifter implements NetworkShifter {
         // In case of asked > 0 : (done - asked) will be < 0, we have Glsk limitation if the next asked value increase (mismatch < 0),
         // In case of asked < 0 : (done - asked) will be > 0, we have Glsk limitation if the next asked value decrease (mismatch > 0)
         if (diffShift < 0 && mismatch < 0 || diffShift > 0 && mismatch > 0) {
-            final String error = "GLSK limitation occurred for country " + country;
-            businessLogger.error(error);
-            throw new GlskLimitationException(error);
+            final String errorMessage = "GLSK limitation occurred for country " + country;
+            businessLogger.error(errorMessage);
+            throw new GlskLimitationException(errorMessage);
         }
     }
 
@@ -290,11 +290,11 @@ public class SweNetworkShifter implements NetworkShifter {
     }
 
     public Map<String, Double> getTargetExchanges(final double stepValue) {
-        return processType == D2CC ? getDayAheadTargetExchanges(stepValue) : getIntradayTargetExchanges(stepValue, initialNetPositions);
+        return processType == D2CC ? getDayAheadTargetExchanges(stepValue) : getIdccTargetExchanges(stepValue, initialNetPositions);
     }
 
-    private Map<String, Double> getIntradayTargetExchanges(final double stepValue,
-                                                           final Map<String, Double> initialNetPositions) {
+    private Map<String, Double> getIdccTargetExchanges(final double stepValue,
+                                                       final Map<String, Double> initialNetPositions) {
         return switch (direction) {
             case ES_FR -> Map.of(ES_PT, -initialNetPositions.get(PT_EIC), ES_FR, stepValue);
             case FR_ES -> Map.of(ES_PT, -initialNetPositions.get(PT_EIC), ES_FR, -stepValue);

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -88,8 +88,7 @@ public class SweNetworkShifter implements NetworkShifter {
     }
 
     @Override
-    public void shiftNetwork(final double stepValue,
-                             final Network network) throws GlskLimitationException, ShiftingException {
+    public void shiftNetwork(final double stepValue, final Network network) throws GlskLimitationException, ShiftingException {
         final VariantManager variantManager = network.getVariantManager();
         businessLogger.info("Starting shift on network {}", variantManager.getWorkingVariantId());
         final Map<String, Double> scalingValuesByCountry = shiftDispatcher.dispatch(stepValue);
@@ -177,8 +176,7 @@ public class SweNetworkShifter implements NetworkShifter {
         }
     }
 
-    private void logShiftSuccess(final int iterationCounter,
-                                 final Map<String, Double> bordersExchanges) {
+    private void logShiftSuccess(final int iterationCounter, final Map<String, Double> bordersExchanges) {
         final String logShiftSucceeded = String.format(
             "[%s] : Shift succeeded after %s iteration ", direction, iterationCounter
         );
@@ -190,8 +188,7 @@ public class SweNetworkShifter implements NetworkShifter {
         businessLogger.info(infoMessage);
     }
 
-    private boolean isWithinTolerances(final double mismatchEsPt,
-                                       final double mismatchEsFr) {
+    private boolean isWithinTolerances(final double mismatchEsPt, final double mismatchEsFr) {
         return Math.abs(mismatchEsPt) < toleranceEsPt && Math.abs(mismatchEsFr) < toleranceEsFr;
     }
 
@@ -211,10 +208,7 @@ public class SweNetworkShifter implements NetworkShifter {
         return incompleteShiftCountries;
     }
 
-    private Optional<Double> computeShift(final String zoneId,
-                                          final Double asked,
-                                          final Network network,
-                                          final ScalingParameters scalingParameters) {
+    private Optional<Double> computeShift(final String zoneId, final Double asked, final Network network, final ScalingParameters scalingParameters) {
         if (zonalScalable.getData(zoneId) == null) {
             return Optional.empty();
         }
@@ -235,9 +229,7 @@ public class SweNetworkShifter implements NetworkShifter {
         }
     }
 
-    private void checkGlskLimitations(final Map<String, Double> incompleteShiftCountries,
-                                      final double mismatchEsPt,
-                                      final double mismatchEsFr) throws GlskLimitationException {
+    private void checkGlskLimitations(final Map<String, Double> incompleteShiftCountries, final double mismatchEsPt, final double mismatchEsFr) throws GlskLimitationException {
 
         final Double ptDiff = incompleteShiftCountries.get(PT_EIC);
         final Double frDiff = incompleteShiftCountries.get(FR_EIC);
@@ -254,9 +246,7 @@ public class SweNetworkShifter implements NetworkShifter {
         }
     }
 
-    private void checkGlskLimitation(final String country,
-                                     final double diffShift,
-                                     final double mismatch) throws GlskLimitationException {
+    private void checkGlskLimitation(final String country, final double diffShift, final double mismatch) throws GlskLimitationException {
         // In case of asked > 0 : (done - asked) will be < 0, we have GLSK limitation if the next asked value increase (mismatch < 0),
         // In case of asked < 0 : (done - asked) will be > 0, we have GLSK limitation if the next asked value decrease (mismatch > 0)
         if (diffShift < 0 && mismatch < 0 || diffShift > 0 && mismatch > 0) {
@@ -316,8 +306,7 @@ public class SweNetworkShifter implements NetworkShifter {
             : getIdccTargetExchanges(stepValue, initialNetPositions);
     }
 
-    private Map<String, Double> getIdccTargetExchanges(final double stepValue,
-                                                       final Map<String, Double> initialNetPositions) {
+    private Map<String, Double> getIdccTargetExchanges(final double stepValue, final Map<String, Double> initialNetPositions) {
         final double ptNetPosition = initialNetPositions.get(PT_EIC);
         final double esNetPosition = initialNetPositions.get(ES_EIC);
 

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -175,8 +175,7 @@ public class SweNetworkShifter implements NetworkShifter {
         }
     }
 
-    private void logShiftSuccess(final int iterationCounter,
-                                 final Map<String, Double> bordersExchanges) {
+    private void logShiftSuccess(final int iterationCounter, final Map<String, Double> bordersExchanges) {
         final String logShiftSucceeded = String.format(
             "[%s] : Shift succeeded after %s iteration ", direction, iterationCounter
         );

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -123,12 +123,12 @@ public class SweNetworkShifter implements NetworkShifter {
                 // Step 2: Compute exchanges mismatch
                 final LoadFlowResult result = runLoadFlowWithMdc(network, workingVariantCopyId, loadFlowParameters);
                 if (result.isFailed()) {
-                    LOGGER.error("Loadflow computation diverged on network '{}' for direction {}", network.getId(), direction.getDashName());
-                    businessLogger.error("Loadflow computation diverged on network during balancing adjustment");
+                    LOGGER.error("Load flow computation diverged on network '{}' for direction {}", network.getId(), direction.getDashName());
+                    businessLogger.error("Load flow computation diverged on network during balancing adjustment");
                     if (networkExporter != null) {
                         networkExporter.export(network);
                     }
-                    throw new ShiftingException("Loadflow computation diverged during balancing adjustment", BALANCE_LOADFLOW_DIVERGENCE);
+                    throw new ShiftingException("Load flow computation diverged during balancing adjustment", BALANCE_LOADFLOW_DIVERGENCE);
                 }
 
                 bordersExchanges = computeSweBordersExchanges(network);

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -11,16 +11,15 @@ import com.farao_community.farao.dichotomy.api.exceptions.GlskLimitationExceptio
 import com.farao_community.farao.dichotomy.api.exceptions.ShiftingException;
 import com.farao_community.farao.dichotomy.api.results.ReasonInvalid;
 import com.farao_community.farao.dichotomy.shift.ShiftDispatcher;
-import com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil;
 import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfiguration;
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
-import com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode;
 import com.powsybl.glsk.commons.ZonalData;
 import com.powsybl.iidm.modification.scalable.Scalable;
 import com.powsybl.iidm.modification.scalable.ScalingParameters;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
 import org.slf4j.Logger;
@@ -29,6 +28,14 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import static com.farao_community.farao.gridcapa_swe_commons.loadflow.LoadFlowUtil.runLoadFlowWithMdc;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType.D2CC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.ES_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.FR_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.PT_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.shift.CountryBalanceComputation.computeSweBordersExchanges;
+import static com.powsybl.iidm.modification.scalable.ScalingParameters.Priority.RESPECT_OF_VOLUME_ASKED;
 
 /**
  * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
@@ -51,8 +58,20 @@ public class SweNetworkShifter implements NetworkShifter {
     private final ProcessConfiguration processConfiguration;
     private final LoadFlowParameters loadFlowParameters;
     private final NetworkExporter networkExporter;
+    private final boolean runGlskChecksFirst;
 
-    public SweNetworkShifter(Logger businessLogger, ProcessType processType, DichotomyDirection direction, ZonalData<Scalable> zonalScalable, ShiftDispatcher shiftDispatcher, double toleranceEsPt, double toleranceEsFr, Map<String, Double> initialNetPositions, ProcessConfiguration processConfiguration, LoadFlowParameters loadFlowParameters, NetworkExporter networkExporter) { // NOSONAR
+    public SweNetworkShifter(final Logger businessLogger,
+                             final ProcessType processType,
+                             final DichotomyDirection direction,
+                             final ZonalData<Scalable> zonalScalable,
+                             final ShiftDispatcher shiftDispatcher,
+                             final double toleranceEsPt,
+                             final double toleranceEsFr,
+                             final Map<String, Double> initialNetPositions,
+                             final ProcessConfiguration processConfiguration,
+                             final LoadFlowParameters loadFlowParameters,
+                             final NetworkExporter networkExporter,
+                             final boolean runGlskChecksFirst) { // NOSONAR
         this.businessLogger = businessLogger;
         this.processType = processType;
         this.direction = direction;
@@ -64,39 +83,48 @@ public class SweNetworkShifter implements NetworkShifter {
         this.processConfiguration = processConfiguration;
         this.loadFlowParameters = loadFlowParameters;
         this.networkExporter = networkExporter;
+        this.runGlskChecksFirst = runGlskChecksFirst;
     }
 
     @Override
-    public void shiftNetwork(double stepValue, Network network) throws GlskLimitationException, ShiftingException {
-
-        businessLogger.info("Starting shift on network {}", network.getVariantManager().getWorkingVariantId());
-        Map<String, Double> scalingValuesByCountry = shiftDispatcher.dispatch(stepValue);
-        ScalableGeneratorConnector scalableGeneratorConnector = new ScalableGeneratorConnector(zonalScalable);
-        GeneratorLimitsHandler generatorLimitsHandler = new GeneratorLimitsHandler(zonalScalable);
+    public void shiftNetwork(final double stepValue,
+                             final Network network) throws GlskLimitationException, ShiftingException {
+        final VariantManager variantManager = network.getVariantManager();
+        businessLogger.info("Starting shift on network {}", variantManager.getWorkingVariantId());
+        final Map<String, Double> scalingValuesByCountry = shiftDispatcher.dispatch(stepValue);
+        final ScalableGeneratorConnector scalableGeneratorConnector = new ScalableGeneratorConnector(zonalScalable);
+        final GeneratorLimitsHandler generatorLimitsHandler = new GeneratorLimitsHandler(zonalScalable);
 
         try {
-            String logTargetCountriesShift = String.format("Target countries shift [ES = %.2f, FR = %.2f, PT = %.2f]", scalingValuesByCountry.get(SweEICode.ES_EIC), scalingValuesByCountry.get(SweEICode.FR_EIC), scalingValuesByCountry.get(SweEICode.PT_EIC));
+            final String logTargetCountriesShift = String.format("Target countries shift [ES = %.2f, FR = %.2f, PT = %.2f]",
+                                                                 scalingValuesByCountry.get(ES_EIC), scalingValuesByCountry.get(FR_EIC), scalingValuesByCountry.get(PT_EIC));
             businessLogger.info(logTargetCountriesShift);
-            Map<String, Double> targetExchanges = getTargetExchanges(stepValue);
+            final Map<String, Double> targetExchanges = getTargetExchanges(stepValue);
             int iterationCounter = 1;
-            boolean shiftSucceed = false;
-
-            String initialVariantId = network.getVariantManager().getWorkingVariantId();
-            String processedVariantId = initialVariantId + " PROCESSED COPY";
-            String workingVariantCopyId = initialVariantId + " WORKING COPY";
-            preProcessNetwork(network, scalableGeneratorConnector, generatorLimitsHandler, initialVariantId, processedVariantId, workingVariantCopyId);
+            boolean shiftSucceeded = false;
+            final String initialVariantId = variantManager.getWorkingVariantId();
+            final String processedVariantId = initialVariantId + " PROCESSED COPY";
+            final String workingVariantCopyId = initialVariantId + " WORKING COPY";
+            preProcessNetwork(network,
+                              scalableGeneratorConnector,
+                              generatorLimitsHandler,
+                              initialVariantId,
+                              processedVariantId,
+                              workingVariantCopyId);
             Map<String, Double> bordersExchanges;
-
-            int maxIterationNumber = processConfiguration.getShiftMaxIterationNumber();
-            ScalingParameters scalingParameters = getScalingParameters();
+            final int maxIterationNumber = processConfiguration.getShiftMaxIterationNumber();
+            final ScalingParameters scalingParameters = getScalingParameters();
 
             do {
                 // Step 1: Perform the scaling
                 LOGGER.info("[{}] : Applying shift iteration {} ", direction, iterationCounter);
-                Map<String, Double> incompleteShiftCountries = shiftIteration(network, scalingValuesByCountry, scalingParameters, scalableGeneratorConnector);
-
+                final Map<String, Double> incompleteShiftCountries = shiftIteration(network,
+                                                                                    scalingValuesByCountry,
+                                                                                    scalingParameters,
+                                                                                    scalableGeneratorConnector,
+                                                                                    stepValue);
                 // Step 2: Compute exchanges mismatch
-                final LoadFlowResult result = LoadFlowUtil.runLoadFlowWithMdc(network, workingVariantCopyId, loadFlowParameters);
+                final LoadFlowResult result = runLoadFlowWithMdc(network, workingVariantCopyId, loadFlowParameters);
                 if (result.isFailed()) {
                     LOGGER.error("Loadflow computation diverged on network '{}' for direction {}", network.getId(), direction.getDashName());
                     businessLogger.error("Loadflow computation diverged on network during balancing adjustment");
@@ -105,67 +133,83 @@ public class SweNetworkShifter implements NetworkShifter {
                     }
                     throw new ShiftingException("Loadflow computation diverged during balancing adjustment", ReasonInvalid.BALANCE_LOADFLOW_DIVERGENCE);
                 }
-                bordersExchanges = CountryBalanceComputation.computeSweBordersExchanges(network);
-                double mismatchEsPt = targetExchanges.get(ES_PT) - bordersExchanges.get(ES_PT);
-                double mismatchEsFr = targetExchanges.get(ES_FR) - bordersExchanges.get(ES_FR);
 
-                // Step 3: Checks balance adjustment results
-                if (isShiftSucceed(mismatchEsPt, mismatchEsFr)) {
-                    logShiftSuccess(iterationCounter, bordersExchanges);
-                    network.getVariantManager().cloneVariant(workingVariantCopyId, initialVariantId, true);
-                    shiftSucceed = true;
-                } else {
+                bordersExchanges = computeSweBordersExchanges(network);
+                final double mismatchEsPt = targetExchanges.get(ES_PT) - bordersExchanges.get(ES_PT);
+                final double mismatchEsFr = targetExchanges.get(ES_FR) - bordersExchanges.get(ES_FR);
+
+                // Step 3: Checks GLSK limitation and balance adjustment results
+
+                if (runGlskChecksFirst) {
                     checkGlskLimitation(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
+                }
+                if (hasShiftSucceeded(mismatchEsPt, mismatchEsFr)) {
+                    logShiftSuccess(iterationCounter, bordersExchanges);
+                    variantManager.cloneVariant(workingVariantCopyId, initialVariantId, true);
+                    shiftSucceeded = true;
+                } else {
+                    if (!runGlskChecksFirst) {
+                        checkGlskLimitation(incompleteShiftCountries, mismatchEsPt, mismatchEsFr);
+                    }
                     // Reset current variant with initial state for each iteration (keeping pre-processing)
-                    network.getVariantManager().cloneVariant(processedVariantId, workingVariantCopyId, true);
+                    variantManager.cloneVariant(processedVariantId, workingVariantCopyId, true);
                     updateScalingValuesWithMismatch(scalingValuesByCountry, mismatchEsPt, mismatchEsFr);
                     ++iterationCounter;
                 }
 
-            } while (iterationCounter < maxIterationNumber && !shiftSucceed);
+            } while (iterationCounter < maxIterationNumber && !shiftSucceeded);
 
             // Step 4 : check after iteration max and out of tolerance
-            if (!shiftSucceed) {
-                String message = String.format("Balancing adjustment out of tolerances : Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f", bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR));
+            if (!shiftSucceeded) {
+                String message = String.format("Balancing adjustment out of tolerances : Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f",
+                                               bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR));
                 businessLogger.error(message);
                 throw new ShiftingException(message);
             }
 
             // Step 5: Reset current variant with initial state
-            network.getVariantManager().setWorkingVariant(initialVariantId);
-            network.getVariantManager().removeVariant(processedVariantId);
-            network.getVariantManager().removeVariant(workingVariantCopyId);
+            variantManager.setWorkingVariant(initialVariantId);
+            variantManager.removeVariant(processedVariantId);
+            variantManager.removeVariant(workingVariantCopyId);
         } finally {
             // here set working variant generators pmin and pmax values to initial values
             generatorLimitsHandler.resetInitialPminPmax(network);
         }
     }
 
-    private void logShiftSuccess(int iterationCounter, Map<String, Double> bordersExchanges) {
-        String logShiftSucceded = String.format("[%s] : Shift succeed after %s iteration ", direction, iterationCounter);
-        LOGGER.info(logShiftSucceded);
-        businessLogger.info("Shift succeed after {} iteration ", iterationCounter);
-        String msg = String.format("Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f", bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR));
-        businessLogger.info(msg);
+    private void logShiftSuccess(final int iterationCounter,
+                                 final Map<String, Double> bordersExchanges) {
+        final String logShiftSucceeded = String.format("[%s] : Shift succeeded after %s iteration ",
+                                                       direction, iterationCounter);
+        LOGGER.info(logShiftSucceeded);
+        businessLogger.info("Shift succeeded after {} iteration ", iterationCounter);
+        final String info = String.format("Exchange ES-PT = %.2f , Exchange ES-FR =  %.2f",
+                                          bordersExchanges.get(ES_PT), bordersExchanges.get(ES_FR));
+        businessLogger.info(info);
     }
 
-    private boolean isShiftSucceed(double mismatchEsPt,  double mismatchEsFr) {
+    private boolean hasShiftSucceeded(final double mismatchEsPt,
+                                      final double mismatchEsFr) {
         return Math.abs(mismatchEsPt) < toleranceEsPt && Math.abs(mismatchEsFr) < toleranceEsFr;
     }
 
-    private Map<String, Double> shiftIteration(Network network, Map<String, Double> scalingValuesByCountry, ScalingParameters scalingParameters, ScalableGeneratorConnector scalableGeneratorConnector) {
-        Map<String, Double> incompleteShiftCountries = new HashMap<>();
-        for (Map.Entry<String, Double> entry : scalingValuesByCountry.entrySet()) {
-            String zoneId = entry.getKey();
+    private Map<String, Double> shiftIteration(final Network network,
+                                               final Map<String, Double> scalingValuesByCountry,
+                                               final ScalingParameters scalingParameters,
+                                               final ScalableGeneratorConnector scalableGeneratorConnector,
+                                               final double stepValue) throws GlskLimitationException {
+        final Map<String, Double> incompleteShiftCountries = new HashMap<>();
+        for (final Map.Entry<String, Double> entry : scalingValuesByCountry.entrySet()) {
+            final String zoneId = entry.getKey();
             if (zonalScalable.getData(zoneId) != null) {
                 double asked = entry.getValue();
-                String logApplyingVariationOnZone = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
-                LOGGER.info(logApplyingVariationOnZone);
+                final String info = String.format("[%s] : Applying variation on zone %s (target: %.2f)", direction, zoneId, asked);
+                LOGGER.info(info);
                 double done = zonalScalable.getData(zoneId).scale(network, asked, scalingParameters);
                 if (Math.abs(done - asked) > DEFAULT_SHIFT_EPSILON) {
-                    String logWarnIncompleteVariation = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
+                    String warning = String.format("[%s] : Incomplete shift on zone %s (target: %.2f, done: %.2f)",
                                                                       direction, zoneId, asked, done);
-                    LOGGER.warn(logWarnIncompleteVariation);
+                    LOGGER.warn(warning);
                     incompleteShiftCountries.put(zoneId, done - asked);
                 }
             }
@@ -176,97 +220,97 @@ public class SweNetworkShifter implements NetworkShifter {
         return incompleteShiftCountries;
     }
 
-    private void checkGlskLimitation(Map<String, Double> incompleteShiftCountries, double mismatchEsPt, double mismatchEsFr) throws GlskLimitationException {
-        if (incompleteShiftCountries.containsKey(SweEICode.PT_EIC)) {
-            checkGlskLimitationCountry("PT", incompleteShiftCountries.get(SweEICode.PT_EIC), mismatchEsPt);
+    private void checkGlskLimitation(final Map<String, Double> incompleteShiftCountries,
+                                     final double mismatchEsPt,
+                                     final double mismatchEsFr) throws GlskLimitationException {
+
+        final Double ptDiff = incompleteShiftCountries.get(PT_EIC);
+        final Double frDiff = incompleteShiftCountries.get(FR_EIC);
+        final Double esDiff = incompleteShiftCountries.get(ES_EIC);
+
+        if (ptDiff != null) {
+            checkGlskLimitationCountry("PT", ptDiff, mismatchEsPt);
         }
-        if (incompleteShiftCountries.containsKey(SweEICode.FR_EIC)) {
-            checkGlskLimitationCountry("FR", incompleteShiftCountries.get(SweEICode.FR_EIC), mismatchEsFr);
+        if (frDiff != null) {
+            checkGlskLimitationCountry("FR", frDiff, mismatchEsFr);
         }
-        if (incompleteShiftCountries.containsKey(SweEICode.ES_EIC)) {
-            checkGlskLimitationCountry("ES", incompleteShiftCountries.get(SweEICode.ES_EIC), -(mismatchEsFr + mismatchEsPt));
+        if (esDiff != null) {
+            checkGlskLimitationCountry("ES", esDiff, -(mismatchEsFr + mismatchEsPt));
         }
     }
 
-    private void checkGlskLimitationCountry(String country, double diffShift, double mismatch) throws GlskLimitationException {
+    private void checkGlskLimitationCountry(final String country,
+                                            final double diffShift,
+                                            final double mismatch) throws GlskLimitationException {
         // In case of asked > 0 : (done - asked) will be < 0, we have Glsk limitation if the next asked value increase (mismatch < 0),
         // In case of asked < 0 : (done - asked) will be > 0, we have Glsk limitation if the next asked value decrease (mismatch > 0)
         if (diffShift < 0 && mismatch < 0 || diffShift > 0 && mismatch > 0) {
-            String msg = "Glsk limitation occurred for country " + country;
-            businessLogger.error(msg);
-            throw new GlskLimitationException(msg);
+            final String error = "GLSK limitation occurred for country " + country;
+            businessLogger.error(error);
+            throw new GlskLimitationException(error);
         }
     }
 
-    private void preProcessNetwork(Network network, ScalableGeneratorConnector scalableGeneratorConnector, GeneratorLimitsHandler generatorLimitsHandler, String initialVariantId, String processedVariantId, String workingVariantCopyId) throws ShiftingException {
-        network.getVariantManager().cloneVariant(initialVariantId, processedVariantId, true);
-        network.getVariantManager().setWorkingVariant(processedVariantId);
+    private void preProcessNetwork(final Network network,
+                                   final ScalableGeneratorConnector scalableGeneratorConnector,
+                                   final GeneratorLimitsHandler generatorLimitsHandler,
+                                   final String initialVariantId,
+                                   final String processedVariantId,
+                                   final String workingVariantCopyId) throws ShiftingException {
+        final VariantManager variantManager = network.getVariantManager();
+        variantManager.cloneVariant(initialVariantId, processedVariantId, true);
+        variantManager.setWorkingVariant(processedVariantId);
         scalableGeneratorConnector.fillGeneratorsInitialState(network, PRE_PROCESSING_COUNTRIES);
         // here set working variant generators pmin and pmax values to default values
         // so that glsk generator pmin and pmax values are used
         generatorLimitsHandler.setPminPmaxToDefaultValue(network, PRE_PROCESSING_COUNTRIES);
-        network.getVariantManager().cloneVariant(processedVariantId, workingVariantCopyId, true);
-        network.getVariantManager().setWorkingVariant(workingVariantCopyId);
+        variantManager.cloneVariant(processedVariantId, workingVariantCopyId, true);
+        variantManager.setWorkingVariant(workingVariantCopyId);
     }
 
     private static ScalingParameters getScalingParameters() {
-        ScalingParameters scalingParameters = new ScalingParameters();
+        final ScalingParameters scalingParameters = new ScalingParameters();
         // RESPECT_OF_VOLUME_ASKED: this parameter allows to do an iterative shift for proportional Glsk until achieving the asked value
         // if in the first iteration some generators was limited by maximum value, the missing power will be distributed to others generators in the next iteration
-        scalingParameters.setPriority(ScalingParameters.Priority.RESPECT_OF_VOLUME_ASKED);
+        scalingParameters.setPriority(RESPECT_OF_VOLUME_ASKED);
         // allow scaling to reconnect generators that are initially disconnected
         scalingParameters.setReconnect(true);
         return scalingParameters;
     }
 
-    public void updateScalingValuesWithMismatch(Map<String, Double> scalingValuesByCountry, double mismatchEsPt, double mismatchEsFr) {
-        if (direction == DichotomyDirection.ES_FR || direction == DichotomyDirection.FR_ES) {
-            scalingValuesByCountry.put(SweEICode.FR_EIC, scalingValuesByCountry.get(SweEICode.FR_EIC) - mismatchEsFr);
-        } else if (direction == DichotomyDirection.ES_PT || direction == DichotomyDirection.PT_ES) {
-            scalingValuesByCountry.put(SweEICode.PT_EIC, scalingValuesByCountry.get(SweEICode.PT_EIC) - mismatchEsPt);
+    public void updateScalingValuesWithMismatch(final Map<String, Double> scalingValuesByCountry,
+                                                final double mismatchEsPt,
+                                                final double mismatchEsFr) {
+        switch (direction) {
+            case ES_FR, FR_ES -> scalingValuesByCountry.put(FR_EIC, scalingValuesByCountry.get(FR_EIC) - mismatchEsFr);
+            case ES_PT, PT_ES -> scalingValuesByCountry.put(PT_EIC, scalingValuesByCountry.get(PT_EIC) - mismatchEsPt);
         }
 
-        scalingValuesByCountry.put(SweEICode.ES_EIC, scalingValuesByCountry.get(SweEICode.ES_EIC) + mismatchEsPt + mismatchEsFr);
+        scalingValuesByCountry.put(ES_EIC, scalingValuesByCountry.get(ES_EIC) + mismatchEsPt + mismatchEsFr);
     }
 
-    public Map<String, Double> getTargetExchanges(double stepValue) {
-        return processType.equals(ProcessType.D2CC) ? getD2ccTargetExchanges(stepValue) : getIdccTargetExchanges(stepValue, initialNetPositions);
+    public Map<String, Double> getTargetExchanges(final double stepValue) {
+        return processType == D2CC ? getDayAheadTargetExchanges(stepValue) : getIntradayTargetExchanges(stepValue, initialNetPositions);
     }
 
-    private Map<String, Double> getIdccTargetExchanges(double stepValue, Map<String, Double> initialNetPositions) {
-        Map<String, Double> target = new HashMap<>();
-        if (DichotomyDirection.ES_FR.equals(direction)) {
-            target.put(ES_PT, -initialNetPositions.get(SweEICode.PT_EIC));
-            target.put(ES_FR, stepValue);
-        } else if (DichotomyDirection.FR_ES.equals(direction)) {
-            target.put(ES_PT, -initialNetPositions.get(SweEICode.PT_EIC));
-            target.put(ES_FR, -stepValue);
-        } else if (DichotomyDirection.ES_PT.equals(direction)) {
-            target.put(ES_PT, stepValue);
-            target.put(ES_FR, initialNetPositions.get(SweEICode.ES_EIC) + initialNetPositions.get(SweEICode.PT_EIC));
-        } else if (DichotomyDirection.PT_ES.equals(direction)) {
-            target.put(ES_PT, -stepValue);
-            target.put(ES_FR, initialNetPositions.get(SweEICode.ES_EIC) + initialNetPositions.get(SweEICode.PT_EIC));
-        }
-        return target;
+    private Map<String, Double> getIntradayTargetExchanges(final double stepValue,
+                                                           final Map<String, Double> initialNetPositions) {
+        return switch (direction) {
+            case ES_FR -> Map.of(ES_PT, -initialNetPositions.get(PT_EIC), ES_FR, stepValue);
+            case FR_ES -> Map.of(ES_PT, -initialNetPositions.get(PT_EIC), ES_FR, -stepValue);
+            case ES_PT ->
+                Map.of(ES_PT, stepValue, ES_FR, initialNetPositions.get(ES_EIC) + initialNetPositions.get(PT_EIC));
+            case PT_ES ->
+                Map.of(ES_PT, -stepValue, ES_FR, initialNetPositions.get(ES_EIC) + initialNetPositions.get(PT_EIC));
+        };
     }
 
-    private Map<String, Double> getD2ccTargetExchanges(double stepValue) {
-        Map<String, Double> target = new HashMap<>();
-        if (DichotomyDirection.ES_FR.equals(direction)) {
-            target.put(ES_PT, 0.);
-            target.put(ES_FR, stepValue);
-        } else if (DichotomyDirection.FR_ES.equals(direction)) {
-            target.put(ES_PT, 0.);
-            target.put(ES_FR, -stepValue);
-        } else if (DichotomyDirection.ES_PT.equals(direction)) {
-            target.put(ES_PT, stepValue);
-            target.put(ES_FR, 0.);
-        } else if (DichotomyDirection.PT_ES.equals(direction)) {
-            target.put(ES_PT, -stepValue);
-            target.put(ES_FR, 0.);
-        }
-        return target;
+    private Map<String, Double> getDayAheadTargetExchanges(final double stepValue) {
+        return switch (direction) {
+            case ES_FR -> Map.of(ES_PT, 0., ES_FR, stepValue);
+            case FR_ES -> Map.of(ES_PT, 0., ES_FR, -stepValue);
+            case ES_PT -> Map.of(ES_PT, stepValue, ES_FR, 0.);
+            case PT_ES -> Map.of(ES_PT, -stepValue, ES_FR, 0.);
+        };
     }
-
 }

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -87,8 +87,7 @@ public class SweNetworkShifter implements NetworkShifter {
     }
 
     @Override
-    public void shiftNetwork(final double stepValue,
-                             final Network network) throws GlskLimitationException, ShiftingException {
+    public void shiftNetwork(final double stepValue, final Network network) throws GlskLimitationException, ShiftingException {
         final VariantManager variantManager = network.getVariantManager();
         businessLogger.info("Starting shift on network {}", variantManager.getWorkingVariantId());
         final Map<String, Double> scalingValuesByCountry = shiftDispatcher.dispatch(stepValue);

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -96,7 +96,8 @@ public class SweNetworkShifter implements NetworkShifter {
 
         try {
             final String targetCountriesShiftMessage = String.format(
-                "Target countries shift [ES = %.2f, FR = %.2f, PT = %.2f]", scalingValuesByCountry.get(ES_EIC), scalingValuesByCountry.get(FR_EIC), scalingValuesByCountry.get(PT_EIC)
+                "Target countries shift [ES = %.2f, FR = %.2f, PT = %.2f]",
+                scalingValuesByCountry.get(ES_EIC), scalingValuesByCountry.get(FR_EIC), scalingValuesByCountry.get(PT_EIC)
             );
             businessLogger.info(targetCountriesShiftMessage);
 

--- a/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
+++ b/gridcapa-swe-commons/src/main/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifter.java
@@ -187,8 +187,7 @@ public class SweNetworkShifter implements NetworkShifter {
         businessLogger.info(infoMessage);
     }
 
-    private boolean hasShiftSucceeded(final double mismatchEsPt,
-                                      final double mismatchEsFr) {
+    private boolean hasShiftSucceeded(final double mismatchEsPt, final double mismatchEsFr) {
         return Math.abs(mismatchEsPt) < toleranceEsPt && Math.abs(mismatchEsFr) < toleranceEsFr;
     }
 

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -12,7 +12,6 @@ import com.farao_community.farao.dichotomy.shift.ShiftDispatcher;
 import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfiguration;
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
-import com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode;
 import com.powsybl.glsk.cim.CimGlskDocument;
 import com.powsybl.glsk.commons.ZonalData;
 import com.powsybl.glsk.commons.ZonalDataImpl;
@@ -42,7 +41,14 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.ES_FR;
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.ES_PT;
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.FR_ES;
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.PT_ES;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType.D2CC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType.IDCC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.ES_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.FR_EIC;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.PT_EIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -56,6 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SweNetworkShifterTest {
 
     private static final Double TARGET_P_TOLERANCE = 1e-3;
+    private static final Map<String, Double> DEFAULT_TEST_NPS = Map.of(ES_EIC, 50., FR_EIC, 100., PT_EIC, 150.);
 
     @MockitoBean
     ProcessConfiguration processConfiguration;
@@ -72,99 +79,89 @@ class SweNetworkShifterTest {
         Scalable scalablePT = Scalable.onGenerator("PPT1AA11_generator");
 
         Map<String, Scalable> mapScalable = new HashMap<>();
-        mapScalable.put(SweEICode.FR_EIC, scalableFR);
-        mapScalable.put(SweEICode.ES_EIC, scalableES);
-        mapScalable.put(SweEICode.PT_EIC, scalablePT);
+        mapScalable.put(FR_EIC, scalableFR);
+        mapScalable.put(ES_EIC, scalableES);
+        mapScalable.put(PT_EIC, scalablePT);
         zonalScalable = new ZonalDataImpl<>(mapScalable);
+    }
+
+    private static SweNetworkShifter zeroToleranceShifter(final DichotomyDirection direction,
+                                                          final ProcessType process,
+                                                          final Map<String, Double> initialNetPositions) {
+        return new SweNetworkShifter(null, process, direction, null, null, 0., 0., initialNetPositions, null, null, null, true);
     }
 
     @Test
     void checkD2ccEsFrTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
-                ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(0., shifts.get("ES_PT"), 0.001);
-        assertEquals(1000., shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_FR, D2CC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(0., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkD2ccFrEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
-                DichotomyDirection.FR_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(0., shifts.get("ES_PT"), 0.001);
-        assertEquals(-1000., shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(FR_ES, D2CC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(0., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(-1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkD2ccPtEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
-                DichotomyDirection.PT_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(-1000., shifts.get("ES_PT"), 0.001);
-        assertEquals(0., shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(PT_ES, D2CC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(-1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(0., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkD2ccEsPtTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
-                DichotomyDirection.ES_PT, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(1000., shifts.get("ES_PT"), 0.001);
-        assertEquals(0., shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_PT, D2CC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(0., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkIdccEsFrTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
+        SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_FR, IDCC, DEFAULT_TEST_NPS);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(-150., shifts.get("ES_PT"), 0.001);
-        assertEquals(1000., shifts.get("ES_FR"), 0.001);
+        assertEquals(-150., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkIdccFrEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.FR_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(-150., shifts.get("ES_PT"), 0.001);
-        assertEquals(-1000., shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(FR_ES, IDCC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(-150., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(-1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkIdccEsPtTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.ES_PT, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(1000., shifts.get("ES_PT"), 0.001);
-        assertEquals(200, shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_PT, IDCC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(200, shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void checkIdccPtEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.PT_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
-        Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
-        assertEquals(-1000., shifts.get("ES_PT"), 0.001);
-        assertEquals(200., shifts.get("ES_FR"), 0.001);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(PT_ES, IDCC, DEFAULT_TEST_NPS);
+        final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
+        assertEquals(-1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
+        assertEquals(200., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
     }
 
     @Test
     void shiftNetworkSuccessTest() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(1000., network);
@@ -178,10 +175,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithGlskLimitationEs() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
@@ -189,10 +186,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworSucceedWithIncompleteVariationEs() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(10820, network); // incomplete shift for ES in the first iteration , but no Glsk limitation error
@@ -206,10 +203,11 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworkSuccedWithIncompleteVariationFrAndNoGlskCheck() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(FR_ES, initialNetPositions);
+
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, false);
+                                                                    FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, false);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(4645, network); // incomplete shift for FR in the first iteration , but no Glsk limitation error
@@ -223,10 +221,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworkFailsWithIncompleteVariationFr() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(FR_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4645, network));
@@ -236,10 +234,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworkWithGlskLimitationForFr() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(FR_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4647, network));
@@ -249,10 +247,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithGlskLimitationPt() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_PT, initialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_PT, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                DichotomyDirection.ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(3000., network));
     }
@@ -260,10 +258,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithShiftingException() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(1);
         assertThrows(ShiftingException.class, () -> sweNetworkShifter.shiftNetwork(1000., network));
     }
@@ -274,19 +272,19 @@ class SweNetworkShifterTest {
         Scalable scalablePT = Scalable.onGenerator("PPT1AA11_generator", 0., 9100.0);
 
         Map<String, Scalable> mapScalable = new HashMap<>();
-        mapScalable.put(SweEICode.FR_EIC, scalableFR);
-        mapScalable.put(SweEICode.ES_EIC, scalableES);
-        mapScalable.put(SweEICode.PT_EIC, scalablePT);
+        mapScalable.put(FR_EIC, scalableFR);
+        mapScalable.put(ES_EIC, scalableES);
+        mapScalable.put(PT_EIC, scalablePT);
         return new ZonalDataImpl<>(mapScalable);
     }
 
     @Test
     void shiftNetworkSuccessWithChangePminPmaxFromGlskTest() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2310., SweEICode.FR_EIC, -2310., SweEICode.PT_EIC, 0.);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2310., FR_EIC, -2310., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(9050., network);
@@ -299,60 +297,60 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithGlskLimitationWithChangePminPmaxFromGlskTest() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 231., SweEICode.FR_EIC, -231., SweEICode.PT_EIC, 0.);
+        Map<String, Double> initialNetPositions = Map.of(ES_EIC, 231., FR_EIC, -231., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
 
     @Test
     void updateScalingValuesWithMismatchPtEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
-                Map.of(SweEICode.FR_EIC, 12.0,
-                        SweEICode.ES_EIC, 27.0,
-                        SweEICode.PT_EIC, 1515.0));
+            Map.of(FR_EIC, 12.0,
+                   ES_EIC, 27.0,
+                   PT_EIC, 1515.0));
 
         networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
 
         Assertions.assertThat(scalingValuesByCountry)
-                .containsEntry(SweEICode.FR_EIC, 12.0)
-                .containsEntry(SweEICode.ES_EIC, 45.0)
-                .containsEntry(SweEICode.PT_EIC, 1510.0);
+            .containsEntry(FR_EIC, 12.0)
+            .containsEntry(ES_EIC, 45.0)
+            .containsEntry(PT_EIC, 1510.0);
     }
 
     @Test
     void updateScalingValuesWithMismatchEsPtTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
-                Map.of(SweEICode.FR_EIC, 12.0,
-                        SweEICode.ES_EIC, 27.0,
-                        SweEICode.PT_EIC, 1515.0));
+            Map.of(FR_EIC, 12.0,
+                   ES_EIC, 27.0,
+                   PT_EIC, 1515.0));
 
         networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
 
         Assertions.assertThat(scalingValuesByCountry)
-                .containsEntry(SweEICode.FR_EIC, 12.0)
-                .containsEntry(SweEICode.ES_EIC, 45.0)
-                .containsEntry(SweEICode.PT_EIC, 1510.0);
+            .containsEntry(FR_EIC, 12.0)
+            .containsEntry(ES_EIC, 45.0)
+            .containsEntry(PT_EIC, 1510.0);
     }
 
     @Test
     void updateScalingValuesWithMismatchFrEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
-                Map.of(SweEICode.FR_EIC, 12.0,
-                        SweEICode.ES_EIC, 27.0,
-                        SweEICode.PT_EIC, 1515.0));
+            Map.of(FR_EIC, 12.0,
+                   ES_EIC, 27.0,
+                   PT_EIC, 1515.0));
 
         networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
 
         Assertions.assertThat(scalingValuesByCountry)
-                .containsEntry(SweEICode.FR_EIC, -1.0)
-                .containsEntry(SweEICode.ES_EIC, 45.0)
-                .containsEntry(SweEICode.PT_EIC, 1515.0);
+            .containsEntry(FR_EIC, -1.0)
+            .containsEntry(ES_EIC, 45.0)
+            .containsEntry(PT_EIC, 1515.0);
     }
 
     @Test
@@ -361,16 +359,16 @@ class SweNetworkShifterTest {
                                                                  null, 10, 10, Map.of(),
                                                                  processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
-                Map.of(SweEICode.FR_EIC, 12.0,
-                        SweEICode.ES_EIC, 27.0,
-                        SweEICode.PT_EIC, 1515.0));
+            Map.of(FR_EIC, 12.0,
+                   ES_EIC, 27.0,
+                   PT_EIC, 1515.0));
 
         networkShifter.updateScalingValuesWithMismatch(scalingValuesByCountry, 5.0, 13.0);
 
         Assertions.assertThat(scalingValuesByCountry)
-                .containsEntry(SweEICode.FR_EIC, -1.0)
-                .containsEntry(SweEICode.ES_EIC, 45.0)
-                .containsEntry(SweEICode.PT_EIC, 1515.0);
+            .containsEntry(FR_EIC, -1.0)
+            .containsEntry(ES_EIC, 45.0)
+            .containsEntry(PT_EIC, 1515.0);
     }
 
     @Test
@@ -383,7 +381,7 @@ class SweNetworkShifterTest {
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -435,9 +433,9 @@ class SweNetworkShifterTest {
         ZonalData<Scalable> customZonalScalable = doc.getZonalScalable(network, instant);
         customZonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.PT_ES, initialNetPositions);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(PT_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                DichotomyDirection.PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+                                                                    PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -484,9 +482,9 @@ class SweNetworkShifterTest {
         List<Double> percentages = new ArrayList<>();
         List<Generator> generators;
         generators = network.getGeneratorStream()
-                .filter(generator -> Country.FR.equals(generator.getTerminal().getVoltageLevel().getSubstation().map(Substation::getNullableCountry).orElse(null)))
-                .filter(NetworkUtil::isCorrect)
-                .toList();
+            .filter(generator -> Country.FR.equals(generator.getTerminal().getVoltageLevel().getSubstation().map(Substation::getNullableCountry).orElse(null)))
+            .filter(NetworkUtil::isCorrect)
+            .toList();
         //calculate sum P of country's generators
         double totalCountryP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
         //calculate factor of each generator

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -190,8 +190,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(10820, network); // incomplete shift for ES in the first iteration , but no Glsk limitation error

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -16,7 +16,6 @@ import com.powsybl.glsk.cim.CimGlskDocument;
 import com.powsybl.glsk.commons.ZonalData;
 import com.powsybl.glsk.commons.ZonalDataImpl;
 import com.powsybl.iidm.modification.scalable.Scalable;
-import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Substation;
@@ -34,7 +33,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +47,8 @@ import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessTyp
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.ES_EIC;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.FR_EIC;
 import static com.farao_community.farao.gridcapa_swe_commons.resource.SweEICode.PT_EIC;
+import static com.powsybl.iidm.network.Country.FR;
+import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -323,7 +323,9 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsPtTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
             Map.of(FR_EIC, 12.0,
                    ES_EIC, 27.0,
@@ -339,7 +341,9 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchFrEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
             Map.of(FR_EIC, 12.0,
                    ES_EIC, 27.0,
@@ -355,9 +359,9 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsFrTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, ES_FR, zonalScalable,
-                                                                 null, 10, 10, Map.of(),
-                                                                 processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
             Map.of(FR_EIC, 12.0,
                    ES_EIC, 27.0,
@@ -377,11 +381,12 @@ class SweNetworkShifterTest {
         CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
         Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
         ZonalData<Scalable> customZonalScalable = doc.getZonalScalable(network, instant);
-        customZonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
+        customZonalScalable.addAll(new ZonalDataImpl<>(singletonMap(new EICode(FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -431,11 +436,13 @@ class SweNetworkShifterTest {
         CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
         Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
         ZonalData<Scalable> customZonalScalable = doc.getZonalScalable(network, instant);
-        customZonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
+        customZonalScalable.addAll(new ZonalDataImpl<>(singletonMap(new EICode(FR).getAreaCode(),
+                                                                    getCountryGeneratorsScalableForFR(network))));
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(PT_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -482,7 +489,7 @@ class SweNetworkShifterTest {
         List<Double> percentages = new ArrayList<>();
         List<Generator> generators;
         generators = network.getGeneratorStream()
-            .filter(generator -> Country.FR.equals(generator.getTerminal().getVoltageLevel().getSubstation().map(Substation::getNullableCountry).orElse(null)))
+            .filter(generator -> FR.equals(generator.getTerminal().getVoltageLevel().getSubstation().map(Substation::getNullableCountry).orElse(null)))
             .filter(NetworkUtil::isCorrect)
             .toList();
         //calculate sum P of country's generators

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -308,8 +308,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 231., FR_EIC, -231., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -178,8 +178,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -78,9 +78,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccEsFrTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), 0.001);
         assertEquals(1000., shifts.get("ES_FR"), 0.001);
@@ -88,9 +88,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccFrEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.FR_ES, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.FR_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), 0.001);
         assertEquals(-1000., shifts.get("ES_FR"), 0.001);
@@ -98,9 +98,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccPtEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.PT_ES, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.PT_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), 0.001);
         assertEquals(0., shifts.get("ES_FR"), 0.001);
@@ -108,9 +108,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccEsPtTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.ES_PT, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.ES_PT, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), 0.001);
         assertEquals(0., shifts.get("ES_FR"), 0.001);
@@ -118,9 +118,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccEsFrTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.ES_FR, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), 0.001);
         assertEquals(1000., shifts.get("ES_FR"), 0.001);
@@ -128,9 +128,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccFrEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.FR_ES, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.FR_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), 0.001);
         assertEquals(-1000., shifts.get("ES_FR"), 0.001);
@@ -138,9 +138,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccEsPtTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.ES_PT, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.ES_PT, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), 0.001);
         assertEquals(200, shifts.get("ES_FR"), 0.001);
@@ -148,9 +148,9 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccPtEsTargetExchangesCalculatedCorrectly() {
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.PT_ES, null, null, 0., 0., intialNetPositions, null, null, null);
+                DichotomyDirection.PT_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), 0.001);
         assertEquals(200., shifts.get("ES_FR"), 0.001);
@@ -159,10 +159,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworkSuccessTest() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(1000., network);
@@ -176,10 +176,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithGlskLimitationEs() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
@@ -187,10 +187,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworSucceedWithIncompleteVariationEs() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(10820, network); // incomplete shift for ES in the first iteration , but no Glsk limitation error
@@ -202,12 +202,12 @@ class SweNetworkShifterTest {
     }
 
     @Test
-    void shiftNetworkSuccedWithIncompleteVariationFr() throws GlskLimitationException, ShiftingException {
+    void shiftNetworkSuccedWithIncompleteVariationFrAndNoGlskCheck() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, false);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(4645, network); // incomplete shift for FR in the first iteration , but no Glsk limitation error
@@ -219,12 +219,25 @@ class SweNetworkShifterTest {
     }
 
     @Test
+    void shiftNetworkFailsWithIncompleteVariationFr() {
+        Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+                                                                    DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
+
+        assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4645, network));
+
+    }
+
+    @Test
     void shiftNetworkWithGlskLimitationForFr() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4647, network));
@@ -234,10 +247,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithGlskLimitationPt() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_PT, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_PT, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(3000., network));
     }
@@ -245,10 +258,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithShiftingException() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(1);
         assertThrows(ShiftingException.class, () -> sweNetworkShifter.shiftNetwork(1000., network));
     }
@@ -268,10 +281,10 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworkSuccessWithChangePminPmaxFromGlskTest() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 2310., SweEICode.FR_EIC, -2310., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2310., SweEICode.FR_EIC, -2310., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(9050., network);
@@ -284,17 +297,17 @@ class SweNetworkShifterTest {
     @Test
     void shiftNetworWithGlskLimitationWithChangePminPmaxFromGlskTest() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
-        Map<String, Double> intialNetPositions = Map.of(SweEICode.ES_EIC, 231., SweEICode.FR_EIC, -231., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, intialNetPositions);
+        Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 231., SweEICode.FR_EIC, -231., SweEICode.PT_EIC, 0.);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., intialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
 
     @Test
     void updateScalingValuesWithMismatchPtEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -310,7 +323,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsPtTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -326,7 +339,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchFrEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -342,7 +355,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsFrTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -366,7 +379,7 @@ class SweNetworkShifterTest {
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -420,7 +433,7 @@ class SweNetworkShifterTest {
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.PT_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null);
+                DichotomyDirection.PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.ES_FR;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType.D2CC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -79,8 +81,8 @@ class SweNetworkShifterTest {
     @Test
     void checkD2ccEsFrTargetExchangesCalculatedCorrectly() {
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
+                ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), 0.001);
         assertEquals(1000., shifts.get("ES_FR"), 0.001);
@@ -89,7 +91,7 @@ class SweNetworkShifterTest {
     @Test
     void checkD2ccFrEsTargetExchangesCalculatedCorrectly() {
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
                 DichotomyDirection.FR_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), 0.001);
@@ -99,7 +101,7 @@ class SweNetworkShifterTest {
     @Test
     void checkD2ccPtEsTargetExchangesCalculatedCorrectly() {
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
                 DichotomyDirection.PT_ES, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), 0.001);
@@ -109,7 +111,7 @@ class SweNetworkShifterTest {
     @Test
     void checkD2ccEsPtTargetExchangesCalculatedCorrectly() {
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, D2CC,
                 DichotomyDirection.ES_PT, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), 0.001);
@@ -120,7 +122,7 @@ class SweNetworkShifterTest {
     void checkIdccEsFrTargetExchangesCalculatedCorrectly() {
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 50., SweEICode.FR_EIC, 100., SweEICode.PT_EIC, 150.);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(null, ProcessType.IDCC,
-                DichotomyDirection.ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
+                ES_FR, null, null, 0., 0., initialNetPositions, null, null, null, true);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), 0.001);
         assertEquals(1000., shifts.get("ES_FR"), 0.001);
@@ -160,9 +162,9 @@ class SweNetworkShifterTest {
     void shiftNetworkSuccessTest() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(1000., network);
@@ -177,9 +179,9 @@ class SweNetworkShifterTest {
     void shiftNetworWithGlskLimitationEs() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
@@ -188,9 +190,9 @@ class SweNetworkShifterTest {
     void shiftNetworSucceedWithIncompleteVariationEs() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(10820, network); // incomplete shift for ES in the first iteration , but no Glsk limitation error
@@ -206,7 +208,7 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
                 DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, false);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
@@ -223,7 +225,7 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
                                                                     DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
@@ -236,7 +238,7 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.FR_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
                 DichotomyDirection.FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
@@ -249,7 +251,7 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_PT, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
                 DichotomyDirection.ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(3000., network));
@@ -259,9 +261,9 @@ class SweNetworkShifterTest {
     void shiftNetworWithShiftingException() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2317., SweEICode.FR_EIC, -2317., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(1);
         assertThrows(ShiftingException.class, () -> sweNetworkShifter.shiftNetwork(1000., network));
     }
@@ -282,9 +284,9 @@ class SweNetworkShifterTest {
     void shiftNetworkSuccessWithChangePminPmaxFromGlskTest() throws GlskLimitationException, ShiftingException {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 2310., SweEICode.FR_EIC, -2310., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(9050., network);
@@ -298,16 +300,16 @@ class SweNetworkShifterTest {
     void shiftNetworWithGlskLimitationWithChangePminPmaxFromGlskTest() {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(SweEICode.ES_EIC, 231., SweEICode.FR_EIC, -231., SweEICode.PT_EIC, 0.);
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(11000., network));
     }
 
     @Test
     void updateScalingValuesWithMismatchPtEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, DichotomyDirection.PT_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -323,7 +325,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsPtTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, DichotomyDirection.ES_PT, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -339,7 +341,7 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchFrEsTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, DichotomyDirection.FR_ES, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -355,7 +357,9 @@ class SweNetworkShifterTest {
 
     @Test
     void updateScalingValuesWithMismatchEsFrTest() {
-        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC, DichotomyDirection.ES_FR, zonalScalable, null, 10, 10, Map.of(), processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter networkShifter = new SweNetworkShifter(businessLogger, D2CC, ES_FR, zonalScalable,
+                                                                 null, 10, 10, Map.of(),
+                                                                 processConfiguration, LoadFlowParameters.load(), null, true);
         Map<String, Double> scalingValuesByCountry = new HashMap<>(
                 Map.of(SweEICode.FR_EIC, 12.0,
                         SweEICode.ES_EIC, 27.0,
@@ -377,9 +381,9 @@ class SweNetworkShifterTest {
         ZonalData<Scalable> customZonalScalable = doc.getZonalScalable(network, instant);
         customZonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
-        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
-                DichotomyDirection.ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
+                ES_FR, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);
 
@@ -432,7 +436,7 @@ class SweNetworkShifterTest {
         customZonalScalable.addAll(new ZonalDataImpl<>(Collections.singletonMap(new EICode(Country.FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))));
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(DichotomyDirection.PT_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, ProcessType.D2CC,
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
                 DichotomyDirection.PT_ES, customZonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(100);
         sweNetworkShifter.shiftNetwork(1000., network);

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -267,8 +267,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(1);
         assertThrows(ShiftingException.class, () -> sweNetworkShifter.shiftNetwork(1000., network));
     }

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -446,8 +446,9 @@ class SweNetworkShifterTest {
         CimGlskDocument doc = CimGlskDocument.importGlsk(getClass().getResourceAsStream("/shift/TestCase_with_transformers_glsk.xml"));
         Instant instant = LocalDateTime.of(2023, 7, 31, 7, 30).toInstant(ZoneOffset.UTC);
         ZonalData<Scalable> customZonalScalable = doc.getZonalScalable(network, instant);
-        customZonalScalable.addAll(new ZonalDataImpl<>(singletonMap(new EICode(FR).getAreaCode(),
-                                                                    getCountryGeneratorsScalableForFR(network))));
+        customZonalScalable.addAll(new ZonalDataImpl<>(
+            singletonMap(new EICode(FR).getAreaCode(), getCountryGeneratorsScalableForFR(network))
+        ));
         Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, LoadFlowParameters.load());
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(PT_ES, initialNetPositions);
         SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -253,8 +253,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_PT, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_PT, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(3000., network));
     }

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -241,8 +241,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(FR_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4647, network));

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -86,14 +86,13 @@ class SweNetworkShifterTest {
     }
 
     private static SweNetworkShifter zeroToleranceShifter(final DichotomyDirection direction,
-                                                          final ProcessType process,
-                                                          final Map<String, Double> initialNetPositions) {
-        return new SweNetworkShifter(null, process, direction, null, null, 0., 0., initialNetPositions, null, null, null, true);
+                                                          final ProcessType process) {
+        return new SweNetworkShifter(null, process, direction, null, null, 0., 0., SweNetworkShifterTest.DEFAULT_TEST_NPS, null, null, null, true);
     }
 
     @Test
     void checkD2ccEsFrTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_FR, D2CC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_FR, D2CC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -101,7 +100,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccFrEsTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(FR_ES, D2CC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(FR_ES, D2CC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(0., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(-1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -109,7 +108,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccPtEsTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(PT_ES, D2CC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(PT_ES, D2CC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(0., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -117,7 +116,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkD2ccEsPtTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_PT, D2CC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_PT, D2CC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(0., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -125,7 +124,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccEsFrTargetExchangesCalculatedCorrectly() {
-        SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_FR, IDCC, DEFAULT_TEST_NPS);
+        SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_FR, IDCC);
         Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -133,7 +132,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccFrEsTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(FR_ES, IDCC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(FR_ES, IDCC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-150., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(-1000., shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -141,7 +140,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccEsPtTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_PT, IDCC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(ES_PT, IDCC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(200, shifts.get("ES_FR"), TARGET_P_TOLERANCE);
@@ -149,7 +148,7 @@ class SweNetworkShifterTest {
 
     @Test
     void checkIdccPtEsTargetExchangesCalculatedCorrectly() {
-        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(PT_ES, IDCC, DEFAULT_TEST_NPS);
+        final SweNetworkShifter sweNetworkShifter = zeroToleranceShifter(PT_ES, IDCC);
         final Map<String, Double> shifts = sweNetworkShifter.getTargetExchanges(1000);
         assertEquals(-1000., shifts.get("ES_PT"), TARGET_P_TOLERANCE);
         assertEquals(200., shifts.get("ES_FR"), TARGET_P_TOLERANCE);

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -291,8 +291,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2310., FR_EIC, -2310., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, getZonalWithMinMax(), shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(9050., network);

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -209,8 +209,9 @@ class SweNetworkShifterTest {
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(FR_ES, initialNetPositions);
 
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, false);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, false
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         sweNetworkShifter.shiftNetwork(4645, network); // incomplete shift for FR in the first iteration , but no Glsk limitation error

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -227,8 +227,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(FR_ES, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, FR_ES, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
 
         assertThrows(GlskLimitationException.class, () -> sweNetworkShifter.shiftNetwork(4645, network));

--- a/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
+++ b/gridcapa-swe-commons/src/test/java/com/farao_community/farao/gridcapa_swe_commons/shift/SweNetworkShifterTest.java
@@ -160,8 +160,9 @@ class SweNetworkShifterTest {
         Network network = Network.read(networkFileName, getClass().getResourceAsStream(networkFileName));
         Map<String, Double> initialNetPositions = Map.of(ES_EIC, 2317., FR_EIC, -2317., PT_EIC, 0.);
         ShiftDispatcher shiftDispatcher = new SweD2ccShiftDispatcher(ES_FR, initialNetPositions);
-        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(businessLogger, D2CC,
-                                                                    ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true);
+        SweNetworkShifter sweNetworkShifter = new SweNetworkShifter(
+            businessLogger, D2CC, ES_FR, zonalScalable, shiftDispatcher, 1., 1., initialNetPositions, processConfiguration, LoadFlowParameters.load(), null, true
+        );
 
         Mockito.when(processConfiguration.getShiftMaxIterationNumber()).thenReturn(5);
         sweNetworkShifter.shiftNetwork(1000., network);

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyLogging.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyLogging.java
@@ -7,6 +7,7 @@
 package com.farao_community.farao.swe.runner.app.dichotomy;
 
 import com.farao_community.farao.dichotomy.api.results.DichotomyResult;
+import com.farao_community.farao.dichotomy.api.results.DichotomyStepResult;
 import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfiguration;
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.swe.runner.app.domain.SweData;
@@ -25,6 +26,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.farao_community.farao.swe.runner.app.dichotomy.DichotomyResultHelper.getActivatedActionInCurative;
+import static com.farao_community.farao.swe.runner.app.dichotomy.DichotomyResultHelper.getActivatedActionInPreventive;
+import static com.farao_community.farao.swe.runner.app.dichotomy.DichotomyResultHelper.getLimitingElement;
+import static com.farao_community.farao.swe.runner.app.dichotomy.DichotomyResultHelper.limitingCauseToString;
 
 /**
  * @author Theo Pascoli {@literal <theo.pascoli at rte-france.com>}
@@ -58,7 +64,10 @@ public class DichotomyLogging {
     }
 
     public void logStartDichotomy(final DichotomyParameters parameters) {
-        businessLogger.info("Start dichotomy : minimum dichotomy index: {}, maximum dichotomy index: {}, dichotomy precision: {}", parameters.minValue(), parameters.maxValue(), parameters.precision());
+        businessLogger.info(
+            "Start dichotomy : minimum dichotomy index: {}, maximum dichotomy index: {}, dichotomy precision: {}",
+            parameters.minValue(), parameters.maxValue(), parameters.precision()
+        );
     }
 
     public void logEndOneDichotomy() {
@@ -83,33 +92,43 @@ public class DichotomyLogging {
         final String firstUnsecureTtc = String.valueOf((int) dichotomyResult.getLowestInvalidStepValue());
         final String voltageCheckStatus =  getVoltageCheckResult(direction, voltageMonitoringResult, sweTaskParameters);
         String angleCheckStatus = NONE;
-        final String limitingCause = dichotomyResult.getLimitingCause() != null ? DichotomyResultHelper.limitingCauseToString(dichotomyResult.getLimitingCause()) : NONE;
-        final Crac crac = (direction == DichotomyDirection.ES_FR || direction == DichotomyDirection.FR_ES) ? sweData.getCracFrEs().getCrac() : sweData.getCracEsPt().getCrac();
-        if (dichotomyResult.getLowestInvalidStep() != null && dichotomyResult.getLowestInvalidStep().getRaoResult() != null) {
+        final String limitingCause = dichotomyResult.getLimitingCause() == null ? NONE : limitingCauseToString(dichotomyResult.getLimitingCause());
+        final Crac crac = (isBetweenFranceAndSpain(direction) ? sweData.getCracFrEs() : sweData.getCracEsPt()).getCrac();
+
+        if (hasRaoResult(dichotomyResult.getLowestInvalidStep())) {
             final RaoResult raoResult = dichotomyResult.getLowestInvalidStep().getRaoResult();
-            limitingElement = DichotomyResultHelper.getLimitingElement(crac, raoResult);
+            limitingElement = getLimitingElement(crac, raoResult);
         }
-        if (dichotomyResult.hasValidStep() && dichotomyResult.getHighestValidStep().getRaoResult() != null) {
+        if (dichotomyResult.hasValidStep() && hasRaoResult(dichotomyResult.getHighestValidStep())) {
             final RaoResult raoResult = dichotomyResult.getHighestValidStep().getRaoResult();
-            printablePrasIds = toString(DichotomyResultHelper.getActivatedActionInPreventive(crac, raoResult));
-            printableCrasIds = toString(DichotomyResultHelper.getActivatedActionInCurative(crac, raoResult));
-            if (dichotomyResult.getHighestValidStep().getValidationData() != null && dichotomyResult.getHighestValidStep().getValidationData().getAngleMonitoringStatus() != null) {
+            printablePrasIds = toString(getActivatedActionInPreventive(crac, raoResult));
+            printableCrasIds = toString(getActivatedActionInCurative(crac, raoResult));
+
+            if (dichotomyResult.getHighestValidStep().getValidationData() != null
+                && dichotomyResult.getHighestValidStep().getValidationData().getAngleMonitoringStatus() != null) {
                 angleCheckStatus = dichotomyResult.getHighestValidStep().getValidationData().getAngleMonitoringStatus().name();
             }
         }
         final Duration difference = Duration.between(startTime, OffsetDateTime.now());
         businessLogger.info(SUMMARY, limitingCause, limitingElement, printablePrasIds, printableCrasIds);
-        businessLogger.info(SUMMARY_BD, timestamp, lastSecureTtc, firstUnsecureTtc, voltageCheckStatus, angleCheckStatus, difference.toHours(), difference.toMinutesPart(), difference.toSecondsPart());
+        businessLogger.info(
+            SUMMARY_BD, timestamp, lastSecureTtc, firstUnsecureTtc, voltageCheckStatus, angleCheckStatus,
+            difference.toHours(), difference.toMinutesPart(), difference.toSecondsPart()
+        );
+    }
+
+    private static boolean hasRaoResult(final DichotomyStepResult<?> stepResult) {
+        return stepResult != null && stepResult.getRaoResult() != null;
     }
 
     private static String toString(final Collection<String> c) {
         return c.stream().map(Object::toString).collect(Collectors.joining(", "));
     }
 
-    private String getVoltageCheckResult(final DichotomyDirection direction,
+    private static String getVoltageCheckResult(final DichotomyDirection direction,
                                          final Optional<RaoResultWithVoltageMonitoring> voltageMonitoringResult,
                                          final SweTaskParameters sweTaskParameters) {
-        if (sweTaskParameters.isRunVoltageCheck() && (direction.equals(DichotomyDirection.FR_ES) || direction.equals(DichotomyDirection.ES_FR))) {
+        if (sweTaskParameters.isRunVoltageCheck() && isBetweenFranceAndSpain(direction)) {
             if (voltageMonitoringResult.isPresent()) {
                 return String.valueOf(voltageMonitoringResult.get().getSecurityStatus());
             } else {
@@ -122,5 +141,9 @@ public class DichotomyLogging {
     private String getTimestampLocalized(final OffsetDateTime timestamp) {
         final OffsetDateTime localOffsetDateTime = OffsetDateTime.ofInstant(timestamp.toInstant(), zoneId);
         return DATE_TIME_FORMATTER.format(localOffsetDateTime);
+    }
+
+    private static boolean isBetweenFranceAndSpain(final DichotomyDirection direction) {
+        return direction.equals(DichotomyDirection.FR_ES) || direction.equals(DichotomyDirection.ES_FR);
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyLogging.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyLogging.java
@@ -58,7 +58,7 @@ public class DichotomyLogging {
     }
 
     public void logStartDichotomy(final DichotomyParameters parameters) {
-        businessLogger.info("Start dichotomy : minimum dichotomy index: {}, maximum dichotomy index: {}, dichotomy precision: {}", parameters.getMinValue(), parameters.getMaxValue(), parameters.getPrecision());
+        businessLogger.info("Start dichotomy : minimum dichotomy index: {}, maximum dichotomy index: {}, dichotomy precision: {}", parameters.minValue(), parameters.maxValue(), parameters.precision());
     }
 
     public void logEndOneDichotomy() {

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
@@ -12,6 +12,7 @@ public class DichotomyParameters {
     private double maxValue;
     private double precision;
     private boolean runAngleCheck;
+    private boolean runGlskChecksFirst;
 
     public double getMinValue() {
         return minValue;
@@ -43,5 +44,13 @@ public class DichotomyParameters {
 
     public void setRunAngleCheck(boolean runAngleCheck) {
         this.runAngleCheck = runAngleCheck;
+    }
+
+    public boolean shouldRunGlskChecksFirst() {
+        return runGlskChecksFirst;
+    }
+
+    public void setRunGlskChecksFirst(final boolean runGlskChecksFirst) {
+        this.runGlskChecksFirst = runGlskChecksFirst;
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
@@ -10,7 +10,7 @@ public record DichotomyParameters(double minValue,
                                   double maxValue,
                                   double precision,
                                   boolean runAngleCheck,
-                                  boolean runGlskChecksFirst) {
+                                  boolean runGlskChecksBeforeLoadFlow) {
 
 
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
@@ -6,51 +6,11 @@
  */
 package com.farao_community.farao.swe.runner.app.dichotomy;
 
-public class DichotomyParameters {
+public record DichotomyParameters(double minValue,
+                                  double maxValue,
+                                  double precision,
+                                  boolean runAngleCheck,
+                                  boolean runGlskChecksFirst) {
 
-    private double minValue;
-    private double maxValue;
-    private double precision;
-    private boolean runAngleCheck;
-    private boolean runGlskChecksFirst;
 
-    public double getMinValue() {
-        return minValue;
-    }
-
-    public void setMinValue(double minValue) {
-        this.minValue = minValue;
-    }
-
-    public double getMaxValue() {
-        return maxValue;
-    }
-
-    public void setMaxValue(double maxValue) {
-        this.maxValue = maxValue;
-    }
-
-    public double getPrecision() {
-        return precision;
-    }
-
-    public void setPrecision(double precision) {
-        this.precision = precision;
-    }
-
-    public boolean isRunAngleCheck() {
-        return runAngleCheck;
-    }
-
-    public void setRunAngleCheck(boolean runAngleCheck) {
-        this.runAngleCheck = runAngleCheck;
-    }
-
-    public boolean shouldRunGlskChecksFirst() {
-        return runGlskChecksFirst;
-    }
-
-    public void setRunGlskChecksFirst(final boolean runGlskChecksFirst) {
-        this.runGlskChecksFirst = runGlskChecksFirst;
-    }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyParameters.java
@@ -11,6 +11,4 @@ public record DichotomyParameters(double minValue,
                                   double precision,
                                   boolean runAngleCheck,
                                   boolean runGlskChecksBeforeLoadFlow) {
-
-
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
@@ -19,6 +19,7 @@ import com.farao_community.farao.swe.runner.app.domain.SweTaskParameters;
 import com.farao_community.farao.swe.runner.app.services.FileExporter;
 import com.farao_community.farao.swe.runner.app.services.FileImporter;
 import com.farao_community.farao.swe.runner.app.services.InterruptionService;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
@@ -61,15 +62,15 @@ public class DichotomyRunner {
     public DichotomyResult<SweDichotomyValidationData> run(final SweData sweData,
                                                            final SweTaskParameters sweTaskParameters,
                                                            final DichotomyDirection direction) {
-        final DichotomyParameters dichotomyParameters = getDichotomyParameters(sweTaskParameters,
-                                                                               direction);
-        dichotomyLogging.logStartDichotomy(dichotomyParameters);
-        final DichotomyEngine<SweDichotomyValidationData> engine = buildDichotomyEngine(sweData,
-                                                                                        direction,
-                                                                                        dichotomyParameters,
-                                                                                        getLoadFlowParameters(sweTaskParameters));
 
-        return engine.run(getNetworkByDirection(sweData, direction));
+        final DichotomyParameters dichotomyParameters = getDichotomyParameters(sweTaskParameters, direction);
+        dichotomyLogging.logStartDichotomy(dichotomyParameters);
+        final DichotomyEngine<SweDichotomyValidationData> engine =
+            buildDichotomyEngine(sweData, direction, dichotomyParameters, getLoadFlowParameters(sweTaskParameters));
+
+        final Network networkForDirection = getNetworkByDirection(sweData, direction);
+
+        return engine.run(networkForDirection);
     }
 
     DichotomyEngine<SweDichotomyValidationData> buildDichotomyEngine(final SweData sweData,
@@ -77,56 +78,50 @@ public class DichotomyRunner {
                                                                      final DichotomyParameters parameters,
                                                                      final LoadFlowParameters loadFlowParameters) {
         return DichotomyEngine.<SweDichotomyValidationData>builder()
-                .withIndex(new Index<>(parameters.getMinValue(), parameters.getMaxValue(), parameters.getPrecision()))
-                .withIndexStrategy(HALF_INDEX_STRATEGY_CONFIGURATION)
-                .withInterruptionStrategy(interruptionService)
-                .withNetworkShifter(networkShifterProvider.get(sweData, direction, loadFlowParameters, parameters.shouldRunGlskChecksFirst()))
-                .withNetworkValidator(getNetworkValidator(sweData, direction, parameters.isRunAngleCheck(), loadFlowParameters))
-                .withRunId(sweData.getId())
-                .build();
+            .withIndex(new Index<>(parameters.minValue(), parameters.maxValue(), parameters.precision()))
+            .withIndexStrategy(HALF_INDEX_STRATEGY_CONFIGURATION)
+            .withInterruptionStrategy(interruptionService)
+            .withNetworkShifter(networkShifterProvider.get(sweData, direction, loadFlowParameters, parameters.runGlskChecksFirst()))
+            .withNetworkValidator(getNetworkValidator(sweData, direction, parameters.runAngleCheck(), loadFlowParameters))
+            .withRunId(sweData.getId())
+            .build();
     }
 
     private NetworkValidator<SweDichotomyValidationData> getNetworkValidator(final SweData sweData,
                                                                              final DichotomyDirection direction,
                                                                              final boolean runAngleCheck,
                                                                              final LoadFlowParameters loadFlowParameters) {
-        return new RaoValidator(fileExporter,
-                                fileImporter,
-                                raoRunnerClient,
-                                sweData,
-                                direction,
-                                runAngleCheck,
-                                loadFlowParameters,
-                                businessLogger);
+        return new RaoValidator(
+            fileExporter, fileImporter, raoRunnerClient, sweData, direction, runAngleCheck, loadFlowParameters, businessLogger
+        );
     }
 
-    private DichotomyParameters getDichotomyParameters(final SweTaskParameters sweTaskParameters,
-                                                       final DichotomyDirection direction) {
-        final DichotomyParameters result = new DichotomyParameters();
-        switch (direction) {
-            case ES_FR -> {
-                result.setMinValue(sweTaskParameters.getMinTtcEsFr());
-                result.setMaxValue(sweTaskParameters.getMaxTtcEsFr());
-                result.setPrecision(sweTaskParameters.getDichotomyPrecisionEsFr());
-            }
-            case FR_ES -> {
-                result.setMinValue(sweTaskParameters.getMinTtcFrEs());
-                result.setMaxValue(sweTaskParameters.getMaxTtcFrEs());
-                result.setPrecision(sweTaskParameters.getDichotomyPrecisionFrEs());
-            }
-            case ES_PT -> {
-                result.setMinValue(sweTaskParameters.getMinTtcEsPt());
-                result.setMaxValue(sweTaskParameters.getMaxTtcEsPt());
-                result.setPrecision(sweTaskParameters.getDichotomyPrecisionEsPt());
-            }
-            case PT_ES -> {
-                result.setMinValue(sweTaskParameters.getMinTtcPtEs());
-                result.setMaxValue(sweTaskParameters.getMaxTtcPtEs());
-                result.setPrecision(sweTaskParameters.getDichotomyPrecisionPtEs());
-            }
-        }
-        result.setRunAngleCheck(sweTaskParameters.isRunAngleCheck());
-        result.setRunGlskChecksFirst(sweTaskParameters.shouldRunGlskChecksFirst());
-        return result;
+    private DichotomyParameters getDichotomyParameters(final SweTaskParameters sweTaskParameters, final DichotomyDirection direction) {
+        final boolean angleCheck = sweTaskParameters.isRunAngleCheck();
+        final boolean glskCheck = sweTaskParameters.shouldRunGlskChecksFirst();
+
+        return switch (direction) {
+            case ES_FR -> new DichotomyParameters(sweTaskParameters.getMinTtcEsFr(),
+                                                  sweTaskParameters.getMaxTtcEsFr(),
+                                                  sweTaskParameters.getDichotomyPrecisionEsFr(),
+                                                  angleCheck,
+                                                  glskCheck);
+            case FR_ES -> new DichotomyParameters(sweTaskParameters.getMinTtcFrEs(),
+                                                  sweTaskParameters.getMaxTtcFrEs(),
+                                                  sweTaskParameters.getDichotomyPrecisionFrEs(),
+                                                  angleCheck,
+                                                  glskCheck);
+            case ES_PT -> new DichotomyParameters(sweTaskParameters.getMinTtcEsPt(),
+                                                  sweTaskParameters.getMaxTtcEsPt(),
+                                                  sweTaskParameters.getDichotomyPrecisionEsPt(),
+                                                  angleCheck,
+                                                  glskCheck);
+            case PT_ES -> new DichotomyParameters(sweTaskParameters.getMinTtcPtEs(),
+                                                  sweTaskParameters.getMaxTtcPtEs(),
+                                                  sweTaskParameters.getDichotomyPrecisionPtEs(),
+                                                  angleCheck,
+                                                  glskCheck);
+        };
+
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
@@ -18,13 +18,13 @@ import com.farao_community.farao.swe.runner.app.domain.SweDichotomyValidationDat
 import com.farao_community.farao.swe.runner.app.domain.SweTaskParameters;
 import com.farao_community.farao.swe.runner.app.services.FileExporter;
 import com.farao_community.farao.swe.runner.app.services.FileImporter;
-import com.farao_community.farao.swe.runner.app.services.NetworkService;
-import com.farao_community.farao.swe.runner.app.utils.OpenLoadFlowParametersUtil;
 import com.farao_community.farao.swe.runner.app.services.InterruptionService;
-import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
+
+import static com.farao_community.farao.swe.runner.app.services.NetworkService.getNetworkByDirection;
+import static com.farao_community.farao.swe.runner.app.utils.OpenLoadFlowParametersUtil.getLoadFlowParameters;
 
 /**
  * @author Theo Pascoli {@literal <theo.pascoli at rte-france.com>}
@@ -42,13 +42,13 @@ public class DichotomyRunner {
 
     private final Logger businessLogger;
 
-    public DichotomyRunner(DichotomyLogging dichotomyLogging,
-                           FileExporter fileExporter,
-                           FileImporter fileImporter,
-                           NetworkShifterProvider networkShifterProvider,
-                           RaoRunnerClient raoRunnerClient,
-                           InterruptionService interruptionService,
-                           Logger businessLogger) {
+    public DichotomyRunner(final DichotomyLogging dichotomyLogging,
+                           final FileExporter fileExporter,
+                           final FileImporter fileImporter,
+                           final NetworkShifterProvider networkShifterProvider,
+                           final RaoRunnerClient raoRunnerClient,
+                           final InterruptionService interruptionService,
+                           final Logger businessLogger) {
         this.dichotomyLogging = dichotomyLogging;
         this.fileExporter = fileExporter;
         this.fileImporter = fileImporter;
@@ -58,32 +58,51 @@ public class DichotomyRunner {
         this.businessLogger = businessLogger;
     }
 
-    public DichotomyResult<SweDichotomyValidationData> run(SweData sweData, SweTaskParameters sweTaskParameters, DichotomyDirection direction) {
-        DichotomyParameters dichotomyParameters = getDichotomyParameters(sweTaskParameters, direction);
-        LoadFlowParameters loadFlowParameters = OpenLoadFlowParametersUtil.getLoadFlowParameters(sweTaskParameters);
+    public DichotomyResult<SweDichotomyValidationData> run(final SweData sweData,
+                                                           final SweTaskParameters sweTaskParameters,
+                                                           final DichotomyDirection direction) {
+        final DichotomyParameters dichotomyParameters = getDichotomyParameters(sweTaskParameters,
+                                                                               direction);
         dichotomyLogging.logStartDichotomy(dichotomyParameters);
-        DichotomyEngine<SweDichotomyValidationData> engine = buildDichotomyEngine(sweData, direction, dichotomyParameters, loadFlowParameters);
-        Network network = NetworkService.getNetworkByDirection(sweData, direction);
-        return engine.run(network);
+        final DichotomyEngine<SweDichotomyValidationData> engine = buildDichotomyEngine(sweData,
+                                                                                        direction,
+                                                                                        dichotomyParameters,
+                                                                                        getLoadFlowParameters(sweTaskParameters));
+
+        return engine.run(getNetworkByDirection(sweData, direction));
     }
 
-    DichotomyEngine<SweDichotomyValidationData> buildDichotomyEngine(SweData sweData, DichotomyDirection direction, DichotomyParameters parameters, LoadFlowParameters loadFlowParameters) {
+    DichotomyEngine<SweDichotomyValidationData> buildDichotomyEngine(final SweData sweData,
+                                                                     final DichotomyDirection direction,
+                                                                     final DichotomyParameters parameters,
+                                                                     final LoadFlowParameters loadFlowParameters) {
         return DichotomyEngine.<SweDichotomyValidationData>builder()
                 .withIndex(new Index<>(parameters.getMinValue(), parameters.getMaxValue(), parameters.getPrecision()))
                 .withIndexStrategy(HALF_INDEX_STRATEGY_CONFIGURATION)
                 .withInterruptionStrategy(interruptionService)
-                .withNetworkShifter(networkShifterProvider.get(sweData, direction, loadFlowParameters))
+                .withNetworkShifter(networkShifterProvider.get(sweData, direction, loadFlowParameters, parameters.shouldRunGlskChecksFirst()))
                 .withNetworkValidator(getNetworkValidator(sweData, direction, parameters.isRunAngleCheck(), loadFlowParameters))
                 .withRunId(sweData.getId())
                 .build();
     }
 
-    private NetworkValidator<SweDichotomyValidationData> getNetworkValidator(SweData sweData, DichotomyDirection direction, boolean runAngleCheck, LoadFlowParameters loadFlowParameters) {
-        return new RaoValidator(fileExporter, fileImporter, raoRunnerClient, sweData, direction, runAngleCheck, loadFlowParameters, businessLogger);
+    private NetworkValidator<SweDichotomyValidationData> getNetworkValidator(final SweData sweData,
+                                                                             final DichotomyDirection direction,
+                                                                             final boolean runAngleCheck,
+                                                                             final LoadFlowParameters loadFlowParameters) {
+        return new RaoValidator(fileExporter,
+                                fileImporter,
+                                raoRunnerClient,
+                                sweData,
+                                direction,
+                                runAngleCheck,
+                                loadFlowParameters,
+                                businessLogger);
     }
 
-    private DichotomyParameters getDichotomyParameters(SweTaskParameters sweTaskParameters, DichotomyDirection direction) {
-        DichotomyParameters result = new DichotomyParameters();
+    private DichotomyParameters getDichotomyParameters(final SweTaskParameters sweTaskParameters,
+                                                       final DichotomyDirection direction) {
+        final DichotomyParameters result = new DichotomyParameters();
         switch (direction) {
             case ES_FR -> {
                 result.setMinValue(sweTaskParameters.getMinTtcEsFr());
@@ -107,6 +126,7 @@ public class DichotomyRunner {
             }
         }
         result.setRunAngleCheck(sweTaskParameters.isRunAngleCheck());
+        result.setRunGlskChecksFirst(sweTaskParameters.shouldRunGlskChecksFirst());
         return result;
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
@@ -98,29 +98,21 @@ public class DichotomyRunner {
 
     private DichotomyParameters getDichotomyParameters(final SweTaskParameters sweTaskParameters, final DichotomyDirection direction) {
         final boolean angleCheck = sweTaskParameters.isRunAngleCheck();
-        final boolean glskCheck = sweTaskParameters.shouldRunGlskChecksFirst();
+        final boolean glskCheck = sweTaskParameters.isRunGlskChecksBeforeLoadFlow();
 
         return switch (direction) {
-            case ES_FR -> new DichotomyParameters(sweTaskParameters.getMinTtcEsFr(),
-                                                  sweTaskParameters.getMaxTtcEsFr(),
+            case ES_FR -> new DichotomyParameters(sweTaskParameters.getMinTtcEsFr(), sweTaskParameters.getMaxTtcEsFr(),
                                                   sweTaskParameters.getDichotomyPrecisionEsFr(),
-                                                  angleCheck,
-                                                  glskCheck);
-            case FR_ES -> new DichotomyParameters(sweTaskParameters.getMinTtcFrEs(),
-                                                  sweTaskParameters.getMaxTtcFrEs(),
+                                                  angleCheck, glskCheck);
+            case FR_ES -> new DichotomyParameters(sweTaskParameters.getMinTtcFrEs(), sweTaskParameters.getMaxTtcFrEs(),
                                                   sweTaskParameters.getDichotomyPrecisionFrEs(),
-                                                  angleCheck,
-                                                  glskCheck);
-            case ES_PT -> new DichotomyParameters(sweTaskParameters.getMinTtcEsPt(),
-                                                  sweTaskParameters.getMaxTtcEsPt(),
+                                                  angleCheck, glskCheck);
+            case ES_PT -> new DichotomyParameters(sweTaskParameters.getMinTtcEsPt(), sweTaskParameters.getMaxTtcEsPt(),
                                                   sweTaskParameters.getDichotomyPrecisionEsPt(),
-                                                  angleCheck,
-                                                  glskCheck);
-            case PT_ES -> new DichotomyParameters(sweTaskParameters.getMinTtcPtEs(),
-                                                  sweTaskParameters.getMaxTtcPtEs(),
+                                                  angleCheck, glskCheck);
+            case PT_ES -> new DichotomyParameters(sweTaskParameters.getMinTtcPtEs(), sweTaskParameters.getMaxTtcPtEs(),
                                                   sweTaskParameters.getDichotomyPrecisionPtEs(),
-                                                  angleCheck,
-                                                  glskCheck);
+                                                  angleCheck, glskCheck);
         };
 
     }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunner.java
@@ -81,7 +81,7 @@ public class DichotomyRunner {
             .withIndex(new Index<>(parameters.minValue(), parameters.maxValue(), parameters.precision()))
             .withIndexStrategy(HALF_INDEX_STRATEGY_CONFIGURATION)
             .withInterruptionStrategy(interruptionService)
-            .withNetworkShifter(networkShifterProvider.get(sweData, direction, loadFlowParameters, parameters.runGlskChecksFirst()))
+            .withNetworkShifter(networkShifterProvider.get(sweData, direction, loadFlowParameters, parameters.runGlskChecksBeforeLoadFlow()))
             .withNetworkValidator(getNetworkValidator(sweData, direction, parameters.runAngleCheck(), loadFlowParameters))
             .withRunId(sweData.getId())
             .build();

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
@@ -58,7 +58,7 @@ public class NetworkShifterProvider {
     public NetworkShifter get(final SweData sweData,
                               final DichotomyDirection direction,
                               final LoadFlowParameters loadFlowParameters,
-                              final boolean runGlskChecksFirst) {
+                              final boolean runGlskChecksBeforeLoadFlow) {
         final ZonalScalableProvider zonalScalableProvider = new ZonalScalableProvider();
         final Network network = NetworkService.getNetworkByDirection(sweData, direction);
         try {
@@ -83,7 +83,7 @@ public class NetworkShifterProvider {
                                          processConfiguration,
                                          loadFlowParameters,
                                          sweNetworkExporter,
-                                         runGlskChecksFirst);
+                                         runGlskChecksBeforeLoadFlow);
 
         } catch (final SweBaseCaseUnsecureException baseCaseUnsecureException) {
             businessLogger.error("Base case loadflow is unsecure, the calculation is stopped and the first unsecure network cannot be exported because it doesn't exist at this stage of the calculation.");

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
@@ -12,7 +12,6 @@ import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfi
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.gridcapa_swe_commons.exception.SweBaseCaseUnsecureException;
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
-import com.farao_community.farao.gridcapa_swe_commons.shift.CountryBalanceComputation;
 import com.farao_community.farao.gridcapa_swe_commons.shift.SweD2ccShiftDispatcher;
 import com.farao_community.farao.gridcapa_swe_commons.shift.SweIdccShiftDispatcher;
 import com.farao_community.farao.gridcapa_swe_commons.shift.SweNetworkShifter;
@@ -29,6 +28,8 @@ import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
+
+import static com.farao_community.farao.gridcapa_swe_commons.shift.CountryBalanceComputation.computeSweCountriesBalances;
 
 /**
  * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
@@ -58,22 +59,26 @@ public class NetworkShifterProvider {
                               final DichotomyDirection direction,
                               final LoadFlowParameters loadFlowParameters,
                               final boolean runGlskChecksFirst) {
-        ZonalScalableProvider zonalScalableProvider = new ZonalScalableProvider();
-        Network network = NetworkService.getNetworkByDirection(sweData, direction);
+        final ZonalScalableProvider zonalScalableProvider = new ZonalScalableProvider();
+        final Network network = NetworkService.getNetworkByDirection(sweData, direction);
         try {
-            Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, loadFlowParameters);
+            final Map<String, Double> initialNetPositions = computeSweCountriesBalances(network, loadFlowParameters);
 
             businessLogger.info("Base case loadflow is secure");
-            final SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork() ?
-                new SweNetworkExporter(sweData, fileExporter) : null;
+
+            final SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork()
+                ? new SweNetworkExporter(sweData, fileExporter)
+                : null;
+
+            final DichotomyConfiguration.Parameters directionParameters = dichotomyConfiguration.getParameters().get(direction);
 
             return new SweNetworkShifter(businessLogger,
                                          sweData.getProcessType(),
                                          direction,
                                          zonalScalableProvider.get(sweData.getGlskUrl(), network, sweData.getTimestamp()),
                                          getShiftDispatcher(sweData.getProcessType(), direction, initialNetPositions),
-                                         dichotomyConfiguration.getParameters().get(direction).getToleranceEsPt(),
-                                         dichotomyConfiguration.getParameters().get(direction).getToleranceEsFr(),
+                                         directionParameters.getToleranceEsPt(),
+                                         directionParameters.getToleranceEsFr(),
                                          initialNetPositions,
                                          processConfiguration,
                                          loadFlowParameters,

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/dichotomy/NetworkShifterProvider.java
@@ -12,7 +12,11 @@ import com.farao_community.farao.gridcapa_swe_commons.configuration.ProcessConfi
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
 import com.farao_community.farao.gridcapa_swe_commons.exception.SweBaseCaseUnsecureException;
 import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
-import com.farao_community.farao.gridcapa_swe_commons.shift.*;
+import com.farao_community.farao.gridcapa_swe_commons.shift.CountryBalanceComputation;
+import com.farao_community.farao.gridcapa_swe_commons.shift.SweD2ccShiftDispatcher;
+import com.farao_community.farao.gridcapa_swe_commons.shift.SweIdccShiftDispatcher;
+import com.farao_community.farao.gridcapa_swe_commons.shift.SweNetworkShifter;
+import com.farao_community.farao.gridcapa_swe_commons.shift.ZonalScalableProvider;
 import com.farao_community.farao.swe.runner.app.configurations.DichotomyConfiguration;
 import com.farao_community.farao.swe.runner.app.configurations.ExportNetworkConfiguration;
 import com.farao_community.farao.swe.runner.app.domain.SweData;
@@ -38,7 +42,11 @@ public class NetworkShifterProvider {
     private final ExportNetworkConfiguration exportNetworkConfiguration;
     private final FileExporter fileExporter;
 
-    public NetworkShifterProvider(DichotomyConfiguration dichotomyConfiguration, Logger businessLogger, ProcessConfiguration processConfiguration, ExportNetworkConfiguration exportNetworkConfiguration, FileExporter fileExporter) {
+    public NetworkShifterProvider(final DichotomyConfiguration dichotomyConfiguration,
+                                  final Logger businessLogger,
+                                  final ProcessConfiguration processConfiguration,
+                                  final ExportNetworkConfiguration exportNetworkConfiguration,
+                                  final FileExporter fileExporter) {
         this.dichotomyConfiguration = dichotomyConfiguration;
         this.businessLogger = businessLogger;
         this.processConfiguration = processConfiguration;
@@ -46,32 +54,44 @@ public class NetworkShifterProvider {
         this.fileExporter = fileExporter;
     }
 
-    public NetworkShifter get(SweData sweData, DichotomyDirection direction, LoadFlowParameters loadFlowParameters) {
+    public NetworkShifter get(final SweData sweData,
+                              final DichotomyDirection direction,
+                              final LoadFlowParameters loadFlowParameters,
+                              final boolean runGlskChecksFirst) {
         ZonalScalableProvider zonalScalableProvider = new ZonalScalableProvider();
         Network network = NetworkService.getNetworkByDirection(sweData, direction);
         try {
             Map<String, Double> initialNetPositions = CountryBalanceComputation.computeSweCountriesBalances(network, loadFlowParameters);
 
             businessLogger.info("Base case loadflow is secure");
-            SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork() ? new SweNetworkExporter(sweData, fileExporter) : null;
-            return new SweNetworkShifter(businessLogger, sweData.getProcessType(), direction,
-                    zonalScalableProvider.get(sweData.getGlskUrl(), network, sweData.getTimestamp()),
-                    getShiftDispatcher(sweData.getProcessType(), direction, initialNetPositions),
-                    dichotomyConfiguration.getParameters().get(direction).getToleranceEsPt(),
-                    dichotomyConfiguration.getParameters().get(direction).getToleranceEsFr(),
-                    initialNetPositions,
-                    processConfiguration,
-                    loadFlowParameters, sweNetworkExporter);
-        } catch (SweBaseCaseUnsecureException baseCaseUnsecureException) {
+            final SweNetworkExporter sweNetworkExporter = exportNetworkConfiguration.isExportFailedNetwork() ?
+                new SweNetworkExporter(sweData, fileExporter) : null;
+
+            return new SweNetworkShifter(businessLogger,
+                                         sweData.getProcessType(),
+                                         direction,
+                                         zonalScalableProvider.get(sweData.getGlskUrl(), network, sweData.getTimestamp()),
+                                         getShiftDispatcher(sweData.getProcessType(), direction, initialNetPositions),
+                                         dichotomyConfiguration.getParameters().get(direction).getToleranceEsPt(),
+                                         dichotomyConfiguration.getParameters().get(direction).getToleranceEsFr(),
+                                         initialNetPositions,
+                                         processConfiguration,
+                                         loadFlowParameters,
+                                         sweNetworkExporter,
+                                         runGlskChecksFirst);
+
+        } catch (final SweBaseCaseUnsecureException baseCaseUnsecureException) {
             businessLogger.error("Base case loadflow is unsecure, the calculation is stopped and the first unsecure network cannot be exported because it doesn't exist at this stage of the calculation.");
             throw baseCaseUnsecureException;
         }
     }
 
-    ShiftDispatcher getShiftDispatcher(ProcessType processType, DichotomyDirection direction, Map<String, Double> initialNetPositions) {
+    ShiftDispatcher getShiftDispatcher(final ProcessType processType,
+                                       final DichotomyDirection direction,
+                                       final Map<String, Double> initialNetPositionsByCountry) {
         return switch (processType) {
-            case D2CC -> new SweD2ccShiftDispatcher(direction, initialNetPositions);
-            case IDCC, IDCC_IDCF, BTCC -> new SweIdccShiftDispatcher(direction, initialNetPositions);
+            case D2CC -> new SweD2ccShiftDispatcher(direction, initialNetPositionsByCountry);
+            case IDCC, IDCC_IDCF, BTCC -> new SweIdccShiftDispatcher(direction, initialNetPositionsByCountry);
         };
     }
 }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
@@ -134,8 +134,7 @@ public class SweTaskParameters {
         return 0; // default return value, won't be used as this return can be reached only in case of validation error
     }
 
-    private int validateIsPositiveIntegerAndGet(final TaskParameterDto parameter,
-                                                final List<String> errors) {
+    private int validateIsPositiveIntegerAndGet(final TaskParameterDto parameter, final List<String> errors) {
         int value = validateIsIntegerAndGet(parameter, errors);
         if (value < 0) {
             errors.add(String.format("Parameter %s should be positive (value: %s)", parameter.getId(), parameter.getValue()));

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
@@ -43,7 +43,7 @@ public class SweTaskParameters {
     private static final String MAX_NEWTON_RAPHSON_ITERATIONS = "MAX_NEWTON_RAPHSON_ITERATIONS";
     private static final String DISABLE_SECOND_PREVENTIVE_RAO = "DISABLE_SECOND_PREVENTIVE_RAO";
     private static final String EXPORT_FIRST_UNSECURE_SHIFTED_CGM = "EXPORT_FIRST_UNSECURE_SHIFTED_CGM";
-    private static final String RUN_GLSK_CHECKS_FIRST = "RUN_GLSK_CHECKS_FIRST";
+    private static final String RUN_GLSK_CHECKS_BEFORE_LOADFLOW = "RUN_GLSK_CHECKS_BEFORE_LOADFLOW";
 
     private boolean runDirectionEsFr;
     private boolean runDirectionFrEs;
@@ -67,7 +67,7 @@ public class SweTaskParameters {
     private int maxNewtonRaphsonIterations;
     private boolean secondPreventiveRaoDisabled;
     private boolean exportFirstUnsecureShiftedCGM;
-    private boolean runGlskChecksFirst;
+    private boolean runGlskChecksBeforeLoadFlow;
 
     public SweTaskParameters(final List<TaskParameterDto> parameters) {
         List<String> errors = new ArrayList<>();
@@ -95,7 +95,7 @@ public class SweTaskParameters {
                 case MAX_NEWTON_RAPHSON_ITERATIONS -> maxNewtonRaphsonIterations = validateIsPositiveIntegerAndGet(parameter, errors);
                 case DISABLE_SECOND_PREVENTIVE_RAO -> secondPreventiveRaoDisabled = validateIsBooleanAndGet(parameter, errors);
                 case EXPORT_FIRST_UNSECURE_SHIFTED_CGM -> exportFirstUnsecureShiftedCGM = validateIsBooleanAndGet(parameter, errors);
-                case RUN_GLSK_CHECKS_FIRST -> runGlskChecksFirst = validateIsBooleanAndGet(parameter, errors);
+                case RUN_GLSK_CHECKS_BEFORE_LOADFLOW -> runGlskChecksBeforeLoadFlow = validateIsBooleanAndGet(parameter, errors);
                 default -> LOGGER.warn("Unknown parameter {} (value: {}) will be ignored", parameter.getId(), parameter.getValue());
             }
         }
@@ -257,7 +257,7 @@ public class SweTaskParameters {
     }
 
     public boolean shouldRunGlskChecksFirst() {
-        return runGlskChecksFirst;
+        return runGlskChecksBeforeLoadFlow;
     }
 
     public String toString() {
@@ -288,7 +288,7 @@ public class SweTaskParameters {
         appender.add(String.format(KEY_VALUE_FORMAT, MAX_NEWTON_RAPHSON_ITERATIONS, maxNewtonRaphsonIterations));
         appender.add(String.format(KEY_VALUE_FORMAT, DISABLE_SECOND_PREVENTIVE_RAO, secondPreventiveRaoDisabled));
         appender.add(String.format(KEY_VALUE_FORMAT, EXPORT_FIRST_UNSECURE_SHIFTED_CGM, exportFirstUnsecureShiftedCGM));
-        appender.add(String.format(KEY_VALUE_FORMAT, RUN_GLSK_CHECKS_FIRST, runGlskChecksFirst));
+        appender.add(String.format(KEY_VALUE_FORMAT, RUN_GLSK_CHECKS_BEFORE_LOADFLOW, runGlskChecksBeforeLoadFlow));
 
         return String.format("{%s%n}", String.join(", ", appender));
     }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
@@ -118,8 +118,7 @@ public class SweTaskParameters {
         }
     }
 
-    private int validateIsIntegerAndGet(final TaskParameterDto parameter,
-                                        final List<String> errors) {
+    private int validateIsIntegerAndGet(final TaskParameterDto parameter, final List<String> errors) {
         if (StringUtils.equals("INT", parameter.getParameterType())) {
             String value = parameter.getValue() != null ? parameter.getValue() : parameter.getDefaultValue();
             try {

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
@@ -108,8 +108,7 @@ public class SweTaskParameters {
         }
     }
 
-    private boolean validateIsBooleanAndGet(final TaskParameterDto parameter,
-                                            final List<String> errors) {
+    private boolean validateIsBooleanAndGet(final TaskParameterDto parameter, final List<String> errors) {
         if (StringUtils.equals("BOOLEAN", parameter.getParameterType())) {
             String value = parameter.getValue() != null ? parameter.getValue() : parameter.getDefaultValue();
             return Boolean.parseBoolean(value);

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
@@ -43,6 +43,7 @@ public class SweTaskParameters {
     private static final String MAX_NEWTON_RAPHSON_ITERATIONS = "MAX_NEWTON_RAPHSON_ITERATIONS";
     private static final String DISABLE_SECOND_PREVENTIVE_RAO = "DISABLE_SECOND_PREVENTIVE_RAO";
     private static final String EXPORT_FIRST_UNSECURE_SHIFTED_CGM = "EXPORT_FIRST_UNSECURE_SHIFTED_CGM";
+    private static final String RUN_GLSK_CHECKS_FIRST = "RUN_GLSK_CHECKS_FIRST";
 
     private boolean runDirectionEsFr;
     private boolean runDirectionFrEs;
@@ -66,8 +67,9 @@ public class SweTaskParameters {
     private int maxNewtonRaphsonIterations;
     private boolean secondPreventiveRaoDisabled;
     private boolean exportFirstUnsecureShiftedCGM;
+    private boolean runGlskChecksFirst;
 
-    public SweTaskParameters(List<TaskParameterDto> parameters) {
+    public SweTaskParameters(final List<TaskParameterDto> parameters) {
         List<String> errors = new ArrayList<>();
         for (TaskParameterDto parameter : parameters) {
             switch (parameter.getId()) {
@@ -93,6 +95,7 @@ public class SweTaskParameters {
                 case MAX_NEWTON_RAPHSON_ITERATIONS -> maxNewtonRaphsonIterations = validateIsPositiveIntegerAndGet(parameter, errors);
                 case DISABLE_SECOND_PREVENTIVE_RAO -> secondPreventiveRaoDisabled = validateIsBooleanAndGet(parameter, errors);
                 case EXPORT_FIRST_UNSECURE_SHIFTED_CGM -> exportFirstUnsecureShiftedCGM = validateIsBooleanAndGet(parameter, errors);
+                case RUN_GLSK_CHECKS_FIRST -> runGlskChecksFirst = validateIsBooleanAndGet(parameter, errors);
                 default -> LOGGER.warn("Unknown parameter {} (value: {}) will be ignored", parameter.getId(), parameter.getValue());
             }
         }
@@ -105,7 +108,8 @@ public class SweTaskParameters {
         }
     }
 
-    private boolean validateIsBooleanAndGet(TaskParameterDto parameter, List<String> errors) {
+    private boolean validateIsBooleanAndGet(final TaskParameterDto parameter,
+                                            final List<String> errors) {
         if (StringUtils.equals("BOOLEAN", parameter.getParameterType())) {
             String value = parameter.getValue() != null ? parameter.getValue() : parameter.getDefaultValue();
             return Boolean.parseBoolean(value);
@@ -115,7 +119,8 @@ public class SweTaskParameters {
         }
     }
 
-    private int validateIsIntegerAndGet(TaskParameterDto parameter, List<String> errors) {
+    private int validateIsIntegerAndGet(final TaskParameterDto parameter,
+                                        final List<String> errors) {
         if (StringUtils.equals("INT", parameter.getParameterType())) {
             String value = parameter.getValue() != null ? parameter.getValue() : parameter.getDefaultValue();
             try {
@@ -129,7 +134,8 @@ public class SweTaskParameters {
         return 0; // default return value, won't be used as this return can be reached only in case of validation error
     }
 
-    private int validateIsPositiveIntegerAndGet(TaskParameterDto parameter, List<String> errors) {
+    private int validateIsPositiveIntegerAndGet(final TaskParameterDto parameter,
+                                                final List<String> errors) {
         int value = validateIsIntegerAndGet(parameter, errors);
         if (value < 0) {
             errors.add(String.format("Parameter %s should be positive (value: %s)", parameter.getId(), parameter.getValue()));
@@ -138,7 +144,7 @@ public class SweTaskParameters {
         return value;
     }
 
-    private void crossValidateParameters(List<String> errors) {
+    private void crossValidateParameters(final List<String> errors) {
         if (runDirectionEsFr) {
             validateStartingPointAndMinPoint("ES-FR", maxTtcEsFr, minTtcEsFr, errors);
         }
@@ -153,7 +159,10 @@ public class SweTaskParameters {
         }
     }
 
-    private void validateStartingPointAndMinPoint(String direction, int startingPointValue, int minPointValue, List<String> errors) {
+    private void validateStartingPointAndMinPoint(final String direction,
+                                                  final int startingPointValue,
+                                                  final int minPointValue,
+                                                  final List<String> errors) {
         if (startingPointValue < minPointValue) {
             errors.add(String.format("[%s] Starting point (value: %d) should be greater than minimum point (value: %d)", direction, startingPointValue, minPointValue));
         }
@@ -247,6 +256,10 @@ public class SweTaskParameters {
         return exportFirstUnsecureShiftedCGM;
     }
 
+    public boolean shouldRunGlskChecksFirst() {
+        return runGlskChecksFirst;
+    }
+
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
@@ -275,6 +288,7 @@ public class SweTaskParameters {
         appender.add(String.format(KEY_VALUE_FORMAT, MAX_NEWTON_RAPHSON_ITERATIONS, maxNewtonRaphsonIterations));
         appender.add(String.format(KEY_VALUE_FORMAT, DISABLE_SECOND_PREVENTIVE_RAO, secondPreventiveRaoDisabled));
         appender.add(String.format(KEY_VALUE_FORMAT, EXPORT_FIRST_UNSECURE_SHIFTED_CGM, exportFirstUnsecureShiftedCGM));
+        appender.add(String.format(KEY_VALUE_FORMAT, RUN_GLSK_CHECKS_FIRST, runGlskChecksFirst));
 
         return String.format("{%s%n}", String.join(", ", appender));
     }

--- a/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
+++ b/gridcapa-swe-runner-app/src/main/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParameters.java
@@ -256,7 +256,7 @@ public class SweTaskParameters {
         return exportFirstUnsecureShiftedCGM;
     }
 
-    public boolean shouldRunGlskChecksFirst() {
+    public boolean isRunGlskChecksBeforeLoadFlow() {
         return runGlskChecksBeforeLoadFlow;
     }
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -180,8 +180,8 @@ class DichotomyRunnerTest {
         final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
         doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
-                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
+            .when(spyDichotomyRunner)
+            .buildDichotomyEngine(anySweData(), anyDirection(), dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
 
         assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), PT_ES));
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -103,8 +103,8 @@ class DichotomyRunnerTest {
         final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
         doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
-                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
+            .when(spyDichotomyRunner)
+            .buildDichotomyEngine(anySweData(), anyDirection(), dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
 
         assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), ES_FR));
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -10,32 +10,39 @@ import com.farao_community.farao.dichotomy.api.DichotomyEngine;
 import com.farao_community.farao.dichotomy.api.NetworkShifter;
 import com.farao_community.farao.dichotomy.api.results.DichotomyResult;
 import com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection;
-import com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType;
 import com.farao_community.farao.rao_runner.api.resource.AbstractRaoResponse;
-import com.farao_community.farao.swe.runner.app.SweTaskParametersTestUtil;
 import com.farao_community.farao.swe.runner.app.domain.SweData;
-import com.farao_community.farao.swe.runner.app.domain.SweDichotomyValidationData;
 import com.farao_community.farao.swe.runner.app.domain.SweTaskParameters;
 import com.farao_community.farao.swe.runner.app.services.FileExporter;
 import com.farao_community.farao.swe.runner.app.services.NetworkService;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowParameters;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.OffsetDateTime;
 
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.ES_FR;
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.ES_PT;
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.FR_ES;
+import static com.farao_community.farao.gridcapa_swe_commons.dichotomy.DichotomyDirection.PT_ES;
+import static com.farao_community.farao.gridcapa_swe_commons.resource.ProcessType.D2CC;
+import static com.farao_community.farao.swe.runner.app.SweTaskParametersTestUtil.getSweTaskParameters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -64,145 +71,141 @@ class DichotomyRunnerTest {
     @Mock
     private LoadFlowParameters loadFlowParameters;
 
+    Network network = mock(Network.class);
+    DichotomyResult<AbstractRaoResponse> mockDichotomyResult = mock(DichotomyResult.class);
+    DichotomyEngine<AbstractRaoResponse> mockEngine = mock(DichotomyEngine.class);
+    DichotomyRunner spyDichotomyRunner;
+
+    @BeforeEach
+    void setUp() {
+        when(mockEngine.run(any(Network.class)))
+            .thenReturn(mockDichotomyResult);
+        spyDichotomyRunner = spy(dichotomyRunner);
+    }
+
     @Test
     void testBuildDichotomyEngine() {
-        when(networkShifterProvider.get(any(SweData.class), any(DichotomyDirection.class), any(LoadFlowParameters.class), any(Boolean.class))).thenReturn(networkShifter);
-        when(fileExporter.saveRaoParameters(eq(OffsetDateTime.now()), eq(ProcessType.D2CC), any(SweTaskParameters.class), eq(DichotomyDirection.ES_FR)))
+        when(networkShifterProvider.get(anySweData(), anyDirection(), any(LoadFlowParameters.class), anyBoolean()))
+            .thenReturn(networkShifter);
+
+        when(fileExporter.saveRaoParameters(eq(OffsetDateTime.now()), eq(D2CC), any(SweTaskParameters.class), eq(ES_FR)))
             .thenReturn("raoParameters.json");
-        DichotomyEngine<SweDichotomyValidationData> engine = dichotomyRunner.buildDichotomyEngine(sweData, DichotomyDirection.ES_FR, dichotomyParameters, loadFlowParameters);
-        assertNotNull(engine);
+
+        assertNotNull(dichotomyRunner.buildDichotomyEngine(sweData, ES_FR, dichotomyParameters, loadFlowParameters));
     }
 
     @Test
     void runDichotomyEsFrTest() {
-        Network network = Mockito.mock(Network.class);
-        DichotomyResult<AbstractRaoResponse> mockDichotomyResult = Mockito.mock(DichotomyResult.class);
-        Mockito.when(NetworkService.getNetworkByDirection(sweData, DichotomyDirection.ES_FR)).thenReturn(network);
-        DichotomyEngine<AbstractRaoResponse> mockEngine = Mockito.mock(DichotomyEngine.class);
-        DichotomyRunner spyDichotomyRunner = Mockito.spy(dichotomyRunner);
-        ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
-        ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
-        Mockito.doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(
-                Mockito.any(SweData.class),
-                Mockito.any(DichotomyDirection.class),
-                dichotomyParametersCaptor.capture(),
-                loadFlowParametersCaptor.capture());
-        Mockito.when(mockEngine.run(Mockito.any(Network.class))).thenReturn(mockDichotomyResult);
-        SweTaskParameters sweTaskParameters = SweTaskParametersTestUtil.getSweTaskParameters();
+        when(NetworkService.getNetworkByDirection(sweData, ES_FR))
+            .thenReturn(network);
 
-        DichotomyResult<SweDichotomyValidationData> dichotomyResult = spyDichotomyRunner.run(sweData, sweTaskParameters, DichotomyDirection.ES_FR);
+        final ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
+        final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
-        assertEquals(mockDichotomyResult, dichotomyResult);
+        doReturn(mockEngine)
+            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
+                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
 
-        DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
+        assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), ES_FR));
+
+        final DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
         assertEquals(82, dichotomyParametersCaptorValue.maxValue());
         assertEquals(42, dichotomyParametersCaptorValue.minValue());
         assertEquals(12, dichotomyParametersCaptorValue.precision());
         assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
-        LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
+        final LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
-        assertEquals(5, loadFlowParametersCaptorValue.getExtension(OpenLoadFlowParameters.class).getMaxNewtonRaphsonIterations());
+        assert5MaxNewtonRaphsonIterations(loadFlowParametersCaptorValue);
     }
 
     @Test
     void runDichotomyFrEsTest() {
-        Network network = Mockito.mock(Network.class);
-        DichotomyResult<AbstractRaoResponse> mockDichotomyResult = Mockito.mock(DichotomyResult.class);
-        Mockito.when(NetworkService.getNetworkByDirection(sweData, DichotomyDirection.FR_ES)).thenReturn(network);
-        DichotomyEngine<AbstractRaoResponse> mockEngine = Mockito.mock(DichotomyEngine.class);
-        DichotomyRunner spyDichotomyRunner = Mockito.spy(dichotomyRunner);
-        ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
-        ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
-        Mockito.doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(
-                Mockito.any(SweData.class),
-                Mockito.any(DichotomyDirection.class),
-                dichotomyParametersCaptor.capture(),
-                loadFlowParametersCaptor.capture());
-        Mockito.when(mockEngine.run(Mockito.any(Network.class))).thenReturn(mockDichotomyResult);
-        SweTaskParameters sweTaskParameters = SweTaskParametersTestUtil.getSweTaskParameters();
-        DichotomyResult<SweDichotomyValidationData> dichotomyResult = spyDichotomyRunner.run(sweData, sweTaskParameters, DichotomyDirection.FR_ES);
+        when(NetworkService.getNetworkByDirection(sweData, FR_ES))
+            .thenReturn(network);
 
-        assertEquals(mockDichotomyResult, dichotomyResult);
+        final ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
+        final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
-        DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
+        doReturn(mockEngine)
+            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
+                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
+
+        assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), FR_ES));
+
+        final DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
         assertEquals(83, dichotomyParametersCaptorValue.maxValue());
         assertEquals(43, dichotomyParametersCaptorValue.minValue());
         assertEquals(13, dichotomyParametersCaptorValue.precision());
         assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
-        LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
+        final LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
-        assertEquals(5, loadFlowParametersCaptorValue.getExtension(OpenLoadFlowParameters.class).getMaxNewtonRaphsonIterations());
+        assert5MaxNewtonRaphsonIterations(loadFlowParametersCaptorValue);
     }
 
     @Test
     void runDichotomyEsPtTest() {
-        Network network = Mockito.mock(Network.class);
-        DichotomyResult<AbstractRaoResponse> mockDichotomyResult = Mockito.mock(DichotomyResult.class);
-        Mockito.when(NetworkService.getNetworkByDirection(sweData, DichotomyDirection.ES_PT)).thenReturn(network);
-        DichotomyEngine<AbstractRaoResponse> mockEngine = Mockito.mock(DichotomyEngine.class);
-        DichotomyRunner spyDichotomyRunner = Mockito.spy(dichotomyRunner);
-        ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
-        ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
-        Mockito.doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(
-                Mockito.any(SweData.class),
-                Mockito.any(DichotomyDirection.class),
-                dichotomyParametersCaptor.capture(),
-                loadFlowParametersCaptor.capture());
-        Mockito.when(mockEngine.run(Mockito.any(Network.class))).thenReturn(mockDichotomyResult);
-        SweTaskParameters sweTaskParameters = SweTaskParametersTestUtil.getSweTaskParameters();
-        DichotomyResult<SweDichotomyValidationData> dichotomyResult = spyDichotomyRunner.run(sweData, sweTaskParameters, DichotomyDirection.ES_PT);
+        when(NetworkService.getNetworkByDirection(sweData, ES_PT))
+            .thenReturn(network);
 
-        assertEquals(mockDichotomyResult, dichotomyResult);
+        final ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
+        final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
-        DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
+        doReturn(mockEngine)
+            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
+                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
+
+        assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), ES_PT));
+
+        final DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
         assertEquals(84, dichotomyParametersCaptorValue.maxValue());
         assertEquals(44, dichotomyParametersCaptorValue.minValue());
         assertEquals(14, dichotomyParametersCaptorValue.precision());
         assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
-        LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
+        final LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
-        assertEquals(5, loadFlowParametersCaptorValue.getExtension(OpenLoadFlowParameters.class).getMaxNewtonRaphsonIterations());
+        assert5MaxNewtonRaphsonIterations(loadFlowParametersCaptorValue);
     }
 
     @Test
     void runDichotomyPtEsTest() {
-        Network network = Mockito.mock(Network.class);
-        DichotomyResult<AbstractRaoResponse> mockDichotomyResult = Mockito.mock(DichotomyResult.class);
-        Mockito.when(NetworkService.getNetworkByDirection(sweData, DichotomyDirection.PT_ES)).thenReturn(network);
-        DichotomyEngine<AbstractRaoResponse> mockEngine = Mockito.mock(DichotomyEngine.class);
-        DichotomyRunner spyDichotomyRunner = Mockito.spy(dichotomyRunner);
-        ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
-        ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
-        Mockito.doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(
-                Mockito.any(SweData.class),
-                Mockito.any(DichotomyDirection.class),
-                dichotomyParametersCaptor.capture(),
-                loadFlowParametersCaptor.capture());
-        Mockito.when(mockEngine.run(Mockito.any(Network.class))).thenReturn(mockDichotomyResult);
-        SweTaskParameters sweTaskParameters = SweTaskParametersTestUtil.getSweTaskParameters();
-        DichotomyResult<SweDichotomyValidationData> dichotomyResult = spyDichotomyRunner.run(sweData, sweTaskParameters, DichotomyDirection.PT_ES);
+        when(NetworkService.getNetworkByDirection(sweData, PT_ES))
+            .thenReturn(network);
+        final ArgumentCaptor<DichotomyParameters> dichotomyParametersCaptor = ArgumentCaptor.forClass(DichotomyParameters.class);
+        final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
-        assertEquals(mockDichotomyResult, dichotomyResult);
+        doReturn(mockEngine)
+            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
+                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
 
-        DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
+        assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), PT_ES));
+
+        final DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
         assertEquals(85, dichotomyParametersCaptorValue.maxValue());
         assertEquals(45, dichotomyParametersCaptorValue.minValue());
         assertEquals(15, dichotomyParametersCaptorValue.precision());
         assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
-        LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
+        final LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
-        assertEquals(5, loadFlowParametersCaptorValue.getExtension(OpenLoadFlowParameters.class).getMaxNewtonRaphsonIterations());
+        assert5MaxNewtonRaphsonIterations(loadFlowParametersCaptorValue);
+    }
+
+    private static SweData anySweData() {
+        return any(SweData.class);
+    }
+
+    private static DichotomyDirection anyDirection() {
+        return any(DichotomyDirection.class);
+    }
+
+    private static void assert5MaxNewtonRaphsonIterations(final LoadFlowParameters loadFlowParameters) {
+        assertEquals(5, loadFlowParameters.getExtension(OpenLoadFlowParameters.class).getMaxNewtonRaphsonIterations());
     }
 }

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -66,7 +66,7 @@ class DichotomyRunnerTest {
 
     @Test
     void testBuildDichotomyEngine() {
-        when(networkShifterProvider.get(any(SweData.class), any(DichotomyDirection.class), any(LoadFlowParameters.class))).thenReturn(networkShifter);
+        when(networkShifterProvider.get(any(SweData.class), any(DichotomyDirection.class), any(LoadFlowParameters.class), any(Boolean.class))).thenReturn(networkShifter);
         when(fileExporter.saveRaoParameters(eq(OffsetDateTime.now()), eq(ProcessType.D2CC), any(SweTaskParameters.class), eq(DichotomyDirection.ES_FR)))
             .thenReturn("raoParameters.json");
         DichotomyEngine<SweDichotomyValidationData> engine = dichotomyRunner.buildDichotomyEngine(sweData, DichotomyDirection.ES_FR, dichotomyParameters, loadFlowParameters);

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -155,8 +155,8 @@ class DichotomyRunnerTest {
         final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
         doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
-                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
+            .when(spyDichotomyRunner)
+            .buildDichotomyEngine(anySweData(), anyDirection(), dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
 
         assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), ES_PT));
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -129,8 +129,8 @@ class DichotomyRunnerTest {
         final ArgumentCaptor<LoadFlowParameters> loadFlowParametersCaptor = ArgumentCaptor.forClass(LoadFlowParameters.class);
 
         doReturn(mockEngine)
-            .when(spyDichotomyRunner).buildDichotomyEngine(anySweData(), anyDirection(),
-                                                           dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
+            .when(spyDichotomyRunner)
+            .buildDichotomyEngine(anySweData(), anyDirection(), dichotomyParametersCaptor.capture(), loadFlowParametersCaptor.capture());
 
         assertEquals(mockDichotomyResult, spyDichotomyRunner.run(sweData, getSweTaskParameters(), FR_ES));
 

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/dichotomy/DichotomyRunnerTest.java
@@ -97,10 +97,10 @@ class DichotomyRunnerTest {
 
         DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
-        assertEquals(82, dichotomyParametersCaptorValue.getMaxValue());
-        assertEquals(42, dichotomyParametersCaptorValue.getMinValue());
-        assertEquals(12, dichotomyParametersCaptorValue.getPrecision());
-        assertTrue(dichotomyParametersCaptorValue.isRunAngleCheck());
+        assertEquals(82, dichotomyParametersCaptorValue.maxValue());
+        assertEquals(42, dichotomyParametersCaptorValue.minValue());
+        assertEquals(12, dichotomyParametersCaptorValue.precision());
+        assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
         LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
@@ -130,10 +130,10 @@ class DichotomyRunnerTest {
 
         DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
-        assertEquals(83, dichotomyParametersCaptorValue.getMaxValue());
-        assertEquals(43, dichotomyParametersCaptorValue.getMinValue());
-        assertEquals(13, dichotomyParametersCaptorValue.getPrecision());
-        assertTrue(dichotomyParametersCaptorValue.isRunAngleCheck());
+        assertEquals(83, dichotomyParametersCaptorValue.maxValue());
+        assertEquals(43, dichotomyParametersCaptorValue.minValue());
+        assertEquals(13, dichotomyParametersCaptorValue.precision());
+        assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
         LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
@@ -163,10 +163,10 @@ class DichotomyRunnerTest {
 
         DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
-        assertEquals(84, dichotomyParametersCaptorValue.getMaxValue());
-        assertEquals(44, dichotomyParametersCaptorValue.getMinValue());
-        assertEquals(14, dichotomyParametersCaptorValue.getPrecision());
-        assertTrue(dichotomyParametersCaptorValue.isRunAngleCheck());
+        assertEquals(84, dichotomyParametersCaptorValue.maxValue());
+        assertEquals(44, dichotomyParametersCaptorValue.minValue());
+        assertEquals(14, dichotomyParametersCaptorValue.precision());
+        assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
         LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);
@@ -196,10 +196,10 @@ class DichotomyRunnerTest {
 
         DichotomyParameters dichotomyParametersCaptorValue = dichotomyParametersCaptor.getValue();
         assertNotNull(dichotomyParametersCaptorValue);
-        assertEquals(85, dichotomyParametersCaptorValue.getMaxValue());
-        assertEquals(45, dichotomyParametersCaptorValue.getMinValue());
-        assertEquals(15, dichotomyParametersCaptorValue.getPrecision());
-        assertTrue(dichotomyParametersCaptorValue.isRunAngleCheck());
+        assertEquals(85, dichotomyParametersCaptorValue.maxValue());
+        assertEquals(45, dichotomyParametersCaptorValue.minValue());
+        assertEquals(15, dichotomyParametersCaptorValue.precision());
+        assertTrue(dichotomyParametersCaptorValue.runAngleCheck());
 
         LoadFlowParameters loadFlowParametersCaptorValue = loadFlowParametersCaptor.getValue();
         assertNotNull(loadFlowParametersCaptorValue);

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
@@ -69,7 +69,7 @@ class SweTaskParametersTest {
         assertThat(params.getMaxNewtonRaphsonIterations()).isEqualTo(38);
         assertThat(params.isSecondPreventiveRaoDisabled()).isTrue();
         assertThat(params.isExportFirstUnsecureShiftedCGM()).isTrue();
-        assertThat(params.shouldRunGlskChecksFirst()).isTrue();
+        assertThat(params.isRunGlskChecksBeforeLoadFlow()).isTrue();
     }
 
     @Test
@@ -108,7 +108,7 @@ class SweTaskParametersTest {
         assertThat(params.getMaxNewtonRaphsonIterations()).isZero();
         assertThat(params.isSecondPreventiveRaoDisabled()).isFalse();
         assertThat(params.isExportFirstUnsecureShiftedCGM()).isFalse();
-        assertThat(params.shouldRunGlskChecksFirst()).isFalse();
+        assertThat(params.isRunGlskChecksBeforeLoadFlow()).isFalse();
     }
 
     @Test

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
@@ -45,7 +45,7 @@ class SweTaskParametersTest {
             new TaskParameterDto("RUN_GLSK_CHECKS_FIRST", "BOOLEAN", "true", "true")
         );
 
-        SweTaskParameters params = new SweTaskParameters(parameters);
+        final SweTaskParameters params = new SweTaskParameters(parameters);
 
         assertThat(params.isRunDirectionEsFr()).isTrue();
         assertThat(params.isRunDirectionFrEs()).isFalse();
@@ -84,7 +84,7 @@ class SweTaskParametersTest {
 
     @Test
     void absentParametersTest() {
-        SweTaskParameters params = new SweTaskParameters(List.of());
+        final SweTaskParameters params = new SweTaskParameters(List.of());
 
         assertThat(params.isRunDirectionEsFr()).isFalse();
         assertThat(params.isRunDirectionFrEs()).isFalse();

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
@@ -42,7 +42,7 @@ class SweTaskParametersTest {
             new TaskParameterDto("MAX_NEWTON_RAPHSON_ITERATIONS", "INT", "38", "63"),
             new TaskParameterDto("DISABLE_SECOND_PREVENTIVE_RAO", "BOOLEAN", "true", "false"),
             new TaskParameterDto("EXPORT_FIRST_UNSECURE_SHIFTED_CGM", "BOOLEAN", "true", "false"),
-            new TaskParameterDto("RUN_GLSK_CHECKS_FIRST", "BOOLEAN", "true", "true")
+            new TaskParameterDto("RUN_GLSK_CHECKS_BEFORE_LOADFLOW", "BOOLEAN", "true", "true")
         );
 
         final SweTaskParameters params = new SweTaskParameters(parameters);

--- a/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
+++ b/gridcapa-swe-runner-app/src/test/java/com/farao_community/farao/swe/runner/app/domain/SweTaskParametersTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class SweTaskParametersTest {
 
     @Test
@@ -39,33 +41,35 @@ class SweTaskParametersTest {
             new TaskParameterDto("MAX_CRA", "INT", "72", "25"),
             new TaskParameterDto("MAX_NEWTON_RAPHSON_ITERATIONS", "INT", "38", "63"),
             new TaskParameterDto("DISABLE_SECOND_PREVENTIVE_RAO", "BOOLEAN", "true", "false"),
-            new TaskParameterDto("EXPORT_FIRST_UNSECURE_SHIFTED_CGM", "BOOLEAN", "true", "false")
+            new TaskParameterDto("EXPORT_FIRST_UNSECURE_SHIFTED_CGM", "BOOLEAN", "true", "false"),
+            new TaskParameterDto("RUN_GLSK_CHECKS_FIRST", "BOOLEAN", "true", "true")
         );
 
-        SweTaskParameters sweTaskParameters = new SweTaskParameters(parameters);
+        SweTaskParameters params = new SweTaskParameters(parameters);
 
-        Assertions.assertThat(sweTaskParameters.isRunDirectionEsFr()).isTrue();
-        Assertions.assertThat(sweTaskParameters.isRunDirectionFrEs()).isFalse();
-        Assertions.assertThat(sweTaskParameters.isRunDirectionEsPt()).isTrue();
-        Assertions.assertThat(sweTaskParameters.isRunDirectionPtEs()).isFalse();
-        Assertions.assertThat(sweTaskParameters.getMaxTtcEsFr()).isEqualTo(42);
-        Assertions.assertThat(sweTaskParameters.getMaxTtcFrEs()).isEqualTo(43);
-        Assertions.assertThat(sweTaskParameters.getMaxTtcEsPt()).isEqualTo(44);
-        Assertions.assertThat(sweTaskParameters.getMaxTtcPtEs()).isEqualTo(45);
-        Assertions.assertThat(sweTaskParameters.getMinTtcEsFr()).isEqualTo(26);
-        Assertions.assertThat(sweTaskParameters.getMinTtcFrEs()).isEqualTo(27);
-        Assertions.assertThat(sweTaskParameters.getMinTtcEsPt()).isEqualTo(28);
-        Assertions.assertThat(sweTaskParameters.getMinTtcPtEs()).isEqualTo(29);
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionEsFr()).isEqualTo(10);
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionFrEs()).isEqualTo(11);
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionEsPt()).isEqualTo(12);
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionPtEs()).isEqualTo(13);
-        Assertions.assertThat(sweTaskParameters.isRunAngleCheck()).isTrue();
-        Assertions.assertThat(sweTaskParameters.isRunVoltageCheck()).isTrue();
-        Assertions.assertThat(sweTaskParameters.getMaxCra()).isEqualTo(72);
-        Assertions.assertThat(sweTaskParameters.getMaxNewtonRaphsonIterations()).isEqualTo(38);
-        Assertions.assertThat(sweTaskParameters.isSecondPreventiveRaoDisabled()).isTrue();
-        Assertions.assertThat(sweTaskParameters.isExportFirstUnsecureShiftedCGM()).isTrue();
+        assertThat(params.isRunDirectionEsFr()).isTrue();
+        assertThat(params.isRunDirectionFrEs()).isFalse();
+        assertThat(params.isRunDirectionEsPt()).isTrue();
+        assertThat(params.isRunDirectionPtEs()).isFalse();
+        assertThat(params.getMaxTtcEsFr()).isEqualTo(42);
+        assertThat(params.getMaxTtcFrEs()).isEqualTo(43);
+        assertThat(params.getMaxTtcEsPt()).isEqualTo(44);
+        assertThat(params.getMaxTtcPtEs()).isEqualTo(45);
+        assertThat(params.getMinTtcEsFr()).isEqualTo(26);
+        assertThat(params.getMinTtcFrEs()).isEqualTo(27);
+        assertThat(params.getMinTtcEsPt()).isEqualTo(28);
+        assertThat(params.getMinTtcPtEs()).isEqualTo(29);
+        assertThat(params.getDichotomyPrecisionEsFr()).isEqualTo(10);
+        assertThat(params.getDichotomyPrecisionFrEs()).isEqualTo(11);
+        assertThat(params.getDichotomyPrecisionEsPt()).isEqualTo(12);
+        assertThat(params.getDichotomyPrecisionPtEs()).isEqualTo(13);
+        assertThat(params.isRunAngleCheck()).isTrue();
+        assertThat(params.isRunVoltageCheck()).isTrue();
+        assertThat(params.getMaxCra()).isEqualTo(72);
+        assertThat(params.getMaxNewtonRaphsonIterations()).isEqualTo(38);
+        assertThat(params.isSecondPreventiveRaoDisabled()).isTrue();
+        assertThat(params.isExportFirstUnsecureShiftedCGM()).isTrue();
+        assertThat(params.shouldRunGlskChecksFirst()).isTrue();
     }
 
     @Test
@@ -75,35 +79,36 @@ class SweTaskParametersTest {
         );
 
         // expected: object is created and no exception is thrown
-        Assertions.assertThat(new SweTaskParameters(parameters)).isInstanceOf(SweTaskParameters.class);
+        assertThat(new SweTaskParameters(parameters)).isInstanceOf(SweTaskParameters.class);
     }
 
     @Test
     void absentParametersTest() {
-        SweTaskParameters sweTaskParameters = new SweTaskParameters(List.of());
+        SweTaskParameters params = new SweTaskParameters(List.of());
 
-        Assertions.assertThat(sweTaskParameters.isRunDirectionEsFr()).isFalse();
-        Assertions.assertThat(sweTaskParameters.isRunDirectionFrEs()).isFalse();
-        Assertions.assertThat(sweTaskParameters.isRunDirectionEsPt()).isFalse();
-        Assertions.assertThat(sweTaskParameters.isRunDirectionPtEs()).isFalse();
-        Assertions.assertThat(sweTaskParameters.getMaxTtcEsFr()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMaxTtcFrEs()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMaxTtcEsPt()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMaxTtcPtEs()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMinTtcEsFr()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMinTtcFrEs()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMinTtcEsPt()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMinTtcPtEs()).isZero();
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionEsFr()).isZero();
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionFrEs()).isZero();
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionEsPt()).isZero();
-        Assertions.assertThat(sweTaskParameters.getDichotomyPrecisionPtEs()).isZero();
-        Assertions.assertThat(sweTaskParameters.isRunAngleCheck()).isFalse();
-        Assertions.assertThat(sweTaskParameters.isRunVoltageCheck()).isFalse();
-        Assertions.assertThat(sweTaskParameters.getMaxCra()).isZero();
-        Assertions.assertThat(sweTaskParameters.getMaxNewtonRaphsonIterations()).isZero();
-        Assertions.assertThat(sweTaskParameters.isSecondPreventiveRaoDisabled()).isFalse();
-        Assertions.assertThat(sweTaskParameters.isExportFirstUnsecureShiftedCGM()).isFalse();
+        assertThat(params.isRunDirectionEsFr()).isFalse();
+        assertThat(params.isRunDirectionFrEs()).isFalse();
+        assertThat(params.isRunDirectionEsPt()).isFalse();
+        assertThat(params.isRunDirectionPtEs()).isFalse();
+        assertThat(params.getMaxTtcEsFr()).isZero();
+        assertThat(params.getMaxTtcFrEs()).isZero();
+        assertThat(params.getMaxTtcEsPt()).isZero();
+        assertThat(params.getMaxTtcPtEs()).isZero();
+        assertThat(params.getMinTtcEsFr()).isZero();
+        assertThat(params.getMinTtcFrEs()).isZero();
+        assertThat(params.getMinTtcEsPt()).isZero();
+        assertThat(params.getMinTtcPtEs()).isZero();
+        assertThat(params.getDichotomyPrecisionEsFr()).isZero();
+        assertThat(params.getDichotomyPrecisionFrEs()).isZero();
+        assertThat(params.getDichotomyPrecisionEsPt()).isZero();
+        assertThat(params.getDichotomyPrecisionPtEs()).isZero();
+        assertThat(params.isRunAngleCheck()).isFalse();
+        assertThat(params.isRunVoltageCheck()).isFalse();
+        assertThat(params.getMaxCra()).isZero();
+        assertThat(params.getMaxNewtonRaphsonIterations()).isZero();
+        assertThat(params.isSecondPreventiveRaoDisabled()).isFalse();
+        assertThat(params.isExportFirstUnsecureShiftedCGM()).isFalse();
+        assertThat(params.shouldRunGlskChecksFirst()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to run GLSK limitation checks before load-flow, controllable via task parameters.

* **Refactor**
  * Dichotomy parameters made immutable and now carry the GLSK-ordering flag; processing updated to propagate this option through dichotomy and shifting.

* **Tests**
  * Unit tests updated to cover GLSK-ordering scenarios and new parameter accessors.

* **Style**
  * Logging and messages refreshed for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->